### PR TITLE
feat: implement universe subtyping with cumulative hierarchy

### DIFF
--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -48,10 +48,12 @@
 #   [:nJ A x P d y p]   - J eliminator (stuck)
 # (Keywords kept for AST readability)
 
+(import ./levels :as lvl)
+
 # ---------------------
 # Type constructors
 # ---------------------
-(defn ty/type [lvl] [T/Type lvl])
+(defn ty/type [lvl] [T/Type (lvl/lvl/value lvl)])
 (defn ty/pi [A B] [T/Pi A B])
 (defn ty/sigma [A B] [T/Sigma A B])
 (defn ty/id [A x y] [T/Id A x y])
@@ -202,6 +204,9 @@
   (let [t1 (if (tuple? v1) (get v1 0) 0)
         t2 (if (tuple? v2) (get v2 0) 0)]
     (cond
+      (and (= t1 T/Type) (= t2 T/Type))
+      (lvl/lvl/eq? (get v1 1) (get v2 1))
+
       (and (= t1 T/Pi) (= t2 T/Pi))
       (let [[_ A1 B1] v1 [_ A2 B2] v2]
         (and (sem-eq ty A1 A2)
@@ -419,6 +424,41 @@
 # Bidirectional checker
 (var infer nil)
 (var check nil)
+(var subtype nil)
+
+(defn- subtype/pi [A1 B1 A2 B2]
+  (and (subtype A2 A1)
+       (let [fresh (gensym)
+             arg-sem (raise A2 (ne/var fresh))]
+         (subtype (B1 arg-sem) (B2 arg-sem)))))
+
+(defn- subtype/sigma [A1 B1 A2 B2]
+  (and (subtype A1 A2)
+       (let [fresh (gensym)
+             arg-sem (raise A1 (ne/var fresh))]
+         (subtype (B1 arg-sem) (B2 arg-sem)))))
+
+(set subtype
+     (fn [A B]
+       "Semantic subtyping with cumulative universes and Pi/Sigma variance."
+       (let [tagA (if (tuple? A) (get A 0) 0)
+             tagB (if (tuple? B) (get B 0) 0)]
+         (cond
+           (and (= tagA T/Type) (= tagB T/Type))
+           (lvl/lvl/<= (get A 1) (get B 1))
+
+           (and (= tagA T/Pi) (= tagB T/Pi))
+           (let [[_ A1 B1] A
+                 [_ A2 B2] B]
+             (subtype/pi A1 B1 A2 B2))
+
+           (and (= tagA T/Sigma) (= tagB T/Sigma))
+           (let [[_ A1 B1] A
+                 [_ A2 B2] B]
+             (subtype/sigma A1 B1 A2 B2))
+
+           true
+           (sem-eq (ty/type 100) A B)))))
 
 (defn check-univ [Γ A]
   "Check that A is a universe and return its level"
@@ -437,7 +477,7 @@
            (ctx/lookup Γ x)
            (errorf "var must be a string or symbol, got: %v" x))
 
-         [:type l] (ty/type (+ l 1))
+          [:type l] (ty/type (lvl/lvl/succ l))
 
          [:lam _] (errorf "cannot infer type of lambda %v; requires annotation" t)
 
@@ -450,21 +490,21 @@
                  (B (eval Γ x))))
              (errorf "application of non-Pi: %v" fA)))
 
-         [:t-pi A B]
-         (let [lvlA (check-univ Γ A)
-               fresh (gensym)
-               A-sem (eval Γ A)
-               Γ2 (ctx/add Γ fresh A-sem)
-               lvlB (check-univ Γ2 (B [:var fresh]))]
-           (ty/type (max lvlA lvlB)))
+          [:t-pi A B]
+          (let [lvlA (check-univ Γ A)
+                fresh (gensym)
+                A-sem (eval Γ A)
+                Γ2 (ctx/add Γ fresh A-sem)
+                lvlB (check-univ Γ2 (B [:var fresh]))]
+            (ty/type (lvl/lvl/max lvlA lvlB)))
 
-         [:t-sigma A B]
-         (let [lvlA (check-univ Γ A)
-               fresh (gensym)
-               A-sem (eval Γ A)
-               Γ2 (ctx/add Γ fresh A-sem)
-               lvlB (check-univ Γ2 (B [:var fresh]))]
-           (ty/type (max lvlA lvlB)))
+          [:t-sigma A B]
+          (let [lvlA (check-univ Γ A)
+                fresh (gensym)
+                A-sem (eval Γ A)
+                Γ2 (ctx/add Γ fresh A-sem)
+                lvlB (check-univ Γ2 (B [:var fresh]))]
+            (ty/type (lvl/lvl/max lvlA lvlB)))
 
          [:fst p]
          (let [pA (infer Γ p)
@@ -555,11 +595,11 @@
                  (check Γ r (B1 (eval Γ l)))))
              (errorf "pair expects Sigma type, got: %v" A)))
 
-         _
-         (let [A1 (infer Γ t)]
-           (if (sem-eq (ty/type 100) A A1)
-             true
-             (errorf "type mismatch: expected %v got %v" A A1))))))
+          _
+          (let [A1 (infer Γ t)]
+            (if (subtype A1 A)
+              true
+              (errorf "type mismatch: expected %v got %v" A A1))))))
 
 # ---------------------
 # Top-level helpers
@@ -637,6 +677,7 @@
    :type-eq type-eq
    :term-eq term-eq
    :check check
+   :subtype subtype
    :infer infer
    :check-top check-top
    :infer-top infer-top

--- a/src/levels.janet
+++ b/src/levels.janet
@@ -1,0 +1,75 @@
+#!/usr/bin/env janet
+
+# Universe levels and displacement algebra.
+
+(def L/Const 0x01)
+(def L/Shift 0x02)
+
+(defn- lvl/check-nat [n who]
+  (when (or (not (int? n)) (< n 0))
+    (errorf "%v expects a non-negative integer, got: %v" who n))
+  n)
+
+(defn lvl/const [n]
+  [L/Const (lvl/check-nat n "lvl/const")])
+
+(defn lvl/shift [n]
+  [L/Shift (lvl/check-nat n "lvl/shift")])
+
+(def lvl/id (lvl/const 0))
+
+(defn lvl/const? [l]
+  (and (tuple? l) (= (get l 0) L/Const)))
+
+(defn lvl/shift? [l]
+  (and (tuple? l) (= (get l 0) L/Shift)))
+
+(defn lvl/value [l]
+  "Normalize a level expression to a concrete natural number."
+  (cond
+    (int? l) (lvl/check-nat l "lvl/value")
+    (lvl/const? l) (lvl/check-nat (get l 1) "lvl/value")
+    (lvl/shift? l) (lvl/check-nat (get l 1) "lvl/value")
+    true (errorf "invalid level expression: %v" l)))
+
+(defn lvl/<= [l1 l2]
+  (<= (lvl/value l1) (lvl/value l2)))
+
+(defn lvl/< [l1 l2]
+  (< (lvl/value l1) (lvl/value l2)))
+
+(defn lvl/eq? [l1 l2]
+  (= (lvl/value l1) (lvl/value l2)))
+
+(defn lvl/succ [l]
+  (inc (lvl/value l)))
+
+(defn lvl/max [l1 l2]
+  (max (lvl/value l1) (lvl/value l2)))
+
+(defn lvl/apply-shift [shift l]
+  (+ (lvl/value shift) (lvl/value l)))
+
+(defn lvl/compose [s1 s2]
+  (lvl/shift (+ (lvl/value s1) (lvl/value s2))))
+
+(defn lvl/str [l]
+  (string "l" (lvl/value l)))
+
+(def exports
+  {:L/Const L/Const
+   :L/Shift L/Shift
+   :const lvl/const
+   :shift lvl/shift
+   :id lvl/id
+   :const? lvl/const?
+   :shift? lvl/shift?
+   :value lvl/value
+   :<= lvl/<=
+   :< lvl/<
+   :eq? lvl/eq?
+   :succ lvl/succ
+   :max lvl/max
+   :apply-shift lvl/apply-shift
+   :compose lvl/compose
+   :str lvl/str})

--- a/test/Core/Levels.janet
+++ b/test/Core/Levels.janet
@@ -1,0 +1,24 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/levels :as lvl)
+
+(test/start-suite "Core Levels")
+
+(test/assert
+  (lvl/lvl/<= (lvl/lvl/const 0) (lvl/lvl/const 3))
+  "const comparison")
+
+(test/assert
+  (= (lvl/lvl/value (lvl/lvl/compose (lvl/lvl/shift 1) (lvl/lvl/shift 2))) 3)
+  "shift composition")
+
+(test/assert
+  (= (lvl/lvl/apply-shift (lvl/lvl/shift 2) (lvl/lvl/const 1)) 3)
+  "shift application")
+
+(test/assert
+  (= (lvl/lvl/succ (lvl/lvl/const 4)) 5)
+  "successor")
+
+(test/end-suite)

--- a/test/Core/Subtyping.janet
+++ b/test/Core/Subtyping.janet
@@ -1,0 +1,60 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/coreTT :as c)
+
+(test/start-suite "Core Subtyping")
+
+# Type subtyping laws
+(let [U0 (c/ty/type 0)
+      U1 (c/ty/type 1)
+      U2 (c/ty/type 2)]
+  (test/assert
+    (c/subtype U1 U1)
+    "Type subtyping is reflexive")
+
+  (test/assert
+    (and (c/subtype U0 U1)
+         (c/subtype U1 U2)
+         (c/subtype U0 U2))
+    "Type subtyping is transitive"))
+
+# Pi subtyping laws with dependent codomain
+(let [dep-pi2 (c/ty/pi (c/ty/type 2) (fn [A] A))
+      dep-pi1 (c/ty/pi (c/ty/type 1) (fn [A] A))
+      dep-pi0 (c/ty/pi (c/ty/type 0) (fn [A] A))]
+  (test/assert
+    (c/subtype dep-pi1 dep-pi1)
+    "Pi subtyping is reflexive")
+
+  (test/assert
+    (and (c/subtype dep-pi2 dep-pi1)
+         (c/subtype dep-pi1 dep-pi0)
+         (c/subtype dep-pi2 dep-pi0))
+    "Pi subtyping is transitive")
+
+  (let [Γ (c/ctx/add (c/ctx/empty) "f" dep-pi2)]
+    (test/assert
+      (c/check Γ [:var "f"] dep-pi1)
+      "Checker applies Pi subsumption with dependent codomain")))
+
+# Sigma subtyping laws with dependent second component
+(let [dep-sig1 (c/ty/sigma (c/ty/type 1) (fn [A] A))
+      dep-sig2 (c/ty/sigma (c/ty/type 2) (fn [A] A))
+      dep-sig3 (c/ty/sigma (c/ty/type 3) (fn [A] A))]
+  (test/assert
+    (c/subtype dep-sig2 dep-sig2)
+    "Sigma subtyping is reflexive")
+
+  (test/assert
+    (and (c/subtype dep-sig1 dep-sig2)
+         (c/subtype dep-sig2 dep-sig3)
+         (c/subtype dep-sig1 dep-sig3))
+    "Sigma subtyping is transitive")
+
+  (let [Γ (c/ctx/add (c/ctx/empty) "p" dep-sig1)]
+    (test/assert
+      (c/check Γ [:var "p"] dep-sig2)
+      "Checker applies Sigma subsumption with dependent codomain")))
+
+(test/end-suite)

--- a/test/Core/Universe.janet
+++ b/test/Core/Universe.janet
@@ -18,6 +18,22 @@
   (= (c/infer-top [:type 5]) [c/T/Type 6])
   "Universe hierarchy: Type₅ : Type₆")
 
+(test/assert
+  (c/check-top [:type 0] (c/ty/type 3))
+  "Cumulativity: Type₀ checks against Type₃")
+
+(test/assert-error
+  (fn [] (c/check-top [:type 3] (c/ty/type 1)))
+  "Cumulativity is not symmetric")
+
+(test/assert
+  (c/subtype (c/ty/type 0) (c/ty/type 4))
+  "Subtype: Type₀ <: Type₄")
+
+(test/assert
+  (not (c/subtype (c/ty/type 4) (c/ty/type 0)))
+  "Subtype: Type₄ is not a subtype of Type₀")
+
 # Property Tests: Universe Hierarchy
 (defn prop-universe-hierarchy [n]
   "Property: Type_l : Type_(l+1)"
@@ -65,5 +81,35 @@
 (test/assert
   (prop-universe-hierarchy-strict 20)
   "Property: universe hierarchy Type_i : Type_(i+1)")
+
+# Property: cumulative universe subsumption chains
+(defn prop-universe-subsumption-chains [n]
+  "Property: Type_i <: Type_j <: Type_k implies Type_i <: Type_k"
+  (var passed true)
+  (repeat n
+    (let [i (math/rng-int rng 6)
+          d1 (inc (math/rng-int rng 4))
+          d2 (inc (math/rng-int rng 4))
+          j (+ i d1)
+          k (+ j d2)
+          Ti (c/ty/type i)
+          Tj (c/ty/type j)
+          Tk (c/ty/type k)]
+      (try
+        (unless (and (c/subtype Ti Ti)
+                     (c/subtype Ti Tj)
+                     (c/subtype Tj Tk)
+                     (c/subtype Ti Tk)
+                     (not (c/subtype Tk Ti)))
+          (set passed false)
+          (print "Universe subsumption chain failed:" i j k))
+        ([err]
+          (set passed false)
+          (print "Universe subsumption chain error:" err)))))
+  passed)
+
+(test/assert
+  (prop-universe-subsumption-chains 40)
+  "Property: cumulative universe subsumption chains")
 
 (test/end-suite)


### PR DESCRIPTION
## Summary
- Implements universe subtyping with cumulative hierarchy (Type₀ <: Type₁)
- Adds semantic subtyping relation with Type, Pi, and Sigma variance
- Updates checker to use subtyping at check-time for better type inference
- Includes comprehensive test suite with property-based tests

## Changes
- **src/coreTT.janet**: Level-aware universes, subtyping relation, checker updates
- **src/levels.janet**: New module for universe level algebra
- **test/Core/Levels.janet**: Level operation tests
- **test/Core/Subtyping.janet**: Subtyping reflexivity/transitivity tests
- **test/Core/Universe.janet**: Cumulative chain property tests

## Validation
- All tests pass: `jpm test` ✅
- Targeted test suites pass: Levels, Universe, Subtyping, Pi, Sigma
- Property-based tests verify cumulative chain properties

This enables proper universe hierarchy and subtyping in the type theory implementation.