### PR TITLE
Fix constructor shadowing in selector matching

### DIFF
--- a/src/lower.janet
+++ b/src/lower.janet
@@ -478,6 +478,12 @@
       (array/push out [:pat/var (p 1)]))
     out))
 
+(defn params/name-set-prefix [params end-exclusive]
+  (let [out @{}]
+    (for i 0 end-exclusive
+      (put out ((params i) 1) true))
+    out))
+
 (defn node/binder [name ty]
   [:list @[(node/atom/new (string name ":")) ty]])
 
@@ -830,8 +836,7 @@
         (when (nil? data-name)
           (errorf "match target %v must have an inductive type head, got: %v" target target-ty))
         (if-let [ctors (get data-env data-name)]
-          (let [param-name-set @{}
-                _ (each p params (put param-name-set (p 1) true))
+          (let [param-name-set (params/name-set-prefix params target-index)
                 _ (match/check-selector-availability target target-ty ctors target-args data-env param-name-set)
                 param-names (map |($ 1) params)
                 entries (match/cases xs)

--- a/test/Properties/SelectorMatching.janet
+++ b/test/Properties/SelectorMatching.janet
@@ -79,6 +79,14 @@
     "    (case vnil: zero) "
     "    (case (vcons x xs'): (succ zero))))"))
 
+(defn mk-shadowed-later-binder-decidable [suffix]
+  (string
+    (mk-base-prefix)
+    "(def okLaterShadow" suffix ": (forall (A: Type). (forall (xs: (Vec A zero)). (forall (zero: Nat). Nat))) "
+    "  (match xs: "
+    "    (case vnil: zero) "
+    "    (case (vcons x xs'): zero)))"))
+
 (test/start-suite "Property Selector Matching")
 
 (let [rng (math/rng 789)]
@@ -128,5 +136,13 @@
       (test/assert
        (lower/error-contains? src "ambiguous selector matching")
        "shadowed constructor names in indices are treated as ambiguous"))))
+
+(let [rng (math/rng 795)]
+  (for _ 0 40
+    (let [suffix (string (math/rng-int rng 100000))
+          src (mk-shadowed-later-binder-decidable suffix)]
+      (test/assert
+       (lower/ok? src)
+       "later binders do not shadow constructor heads in target indices"))))
 
 (test/end-suite)


### PR DESCRIPTION
## Summary
- Selector heads are now treated as ambiguous (`M/Stuck`) when they could be either a constructor or a shadowing binder.
- Added `var-name-set` tracking to distinguish bound parameters from actual constructors.
- Added property tests for constructor-name shadowing in indices (e.g. parameter named `zero` in `(Vec A zero)`).

## Validation
- `jpm test`