### PR TITLE
feat: add indexed-family surface branches and ctor-aware checks

### DIFF
--- a/requiem.janet
+++ b/requiem.janet
@@ -4,6 +4,8 @@
 (import ./src/frontend/sexpr/lower :as l)
 (import ./src/frontend/surface/parser :as sp)
 (import ./src/elab :as e)
+(import ./src/coreTT :as tt)
+(import ./src/matches :as mt)
 
 (defn decl/summary [decl]
   (match decl
@@ -13,11 +15,154 @@
     (string "def " name " (" (length params) " param(s), " (length clauses) " clause(s))")
     [:decl/record header entries]
     (string "record " header " (" (length entries) " entry(ies))")
+    [:decl/compute tm]
+    (string "compute " (string/format "%v" tm))
+    [:decl/compute tm _]
+    (string "compute " (string/format "%v" tm))
+    [:decl/check tm ty]
+    (string "check " (string/format "%v" tm) " : " (string/format "%v" ty))
+    [:decl/check tm ty _]
+    (string "check " (string/format "%v" tm) " : " (string/format "%v" ty))
+    [:core/data name params _ _]
+    (string "data " name " (core)")
+    [:core/func name params _ _ _]
+    (string "def " name " (core)")
+    [:core/compute tm]
+    (string "compute " (string/format "%v" tm))
+    [:core/check tm ty]
+    (string "check " (string/format "%v" tm) " : " (string/format "%v" ty))
     _
-    (string "unknown declaration: " decl)))
+    (string "unknown declaration: " (string/format "%v" decl))))
 
 (defn- surface-file? [path]
   (string/has-suffix? ".requiem" path))
+
+(defn- binders->ctx [params Γ]
+  (reduce (fn [acc b]
+            (match b
+              [:bind name ty-core]
+              (tt/ctx/add acc name (tt/eval acc ty-core))
+              _ acc))
+          Γ
+          params))
+
+(defn- binders->pi-sem [Γ params result-core]
+  (if (zero? (length params))
+    (tt/eval Γ result-core)
+    (let [b (params 0)
+          name (b 1)
+          dom (tt/eval Γ (b 2))
+          rest (slice params 1)]
+      (tt/ty/pi dom
+                (fn [x]
+                  (binders->pi-sem (tt/ctx/add Γ name x) rest result-core))))))
+
+(defn- build-global-ctx [core-decls]
+  (var Γ (tt/ctx/empty))
+  (each decl core-decls
+    (match decl
+      [:core/data name params sort ctors]
+      (do
+        (set Γ (tt/ctx/add Γ name (binders->pi-sem Γ params sort)))
+        (each ctor ctors
+          (let [ctor-name (ctor 1)
+                ctor-ty (ctor 5)]
+            (set Γ (tt/ctx/add Γ ctor-name (tt/eval Γ ctor-ty))))))
+
+      [:core/func name _ _ core-ty _]
+      (set Γ (tt/ctx/add Γ name (tt/eval Γ core-ty)))
+
+      _ nil))
+  Γ)
+
+(defn- term/spine [tm]
+  (var cur tm)
+  (var rev-args @[])
+  (while (and (tuple? cur) (= (cur 0) :app))
+    (array/push rev-args (cur 2))
+    (set cur (cur 1)))
+  (if (and (tuple? cur) (= (cur 0) :var))
+    [(cur 1) (reverse rev-args)]
+    [nil @[]]))
+
+(defn- term/subst [tm sigma]
+  (match tm
+    [:var x]
+    (or (mt/subst/lookup sigma x) tm)
+
+    [:app f a]
+    [:app (term/subst f sigma) (term/subst a sigma)]
+
+    [:t-pi A B]
+    [:t-pi (term/subst A sigma) B]
+
+    [:t-sigma A B]
+    [:t-sigma (term/subst A sigma) B]
+
+    [:pair l r]
+    [:pair (term/subst l sigma) (term/subst r sigma)]
+
+    [:fst p]
+    [:fst (term/subst p sigma)]
+
+    [:snd p]
+    [:snd (term/subst p sigma)]
+
+    [:t-id A x y]
+    [:t-id (term/subst A sigma) (term/subst x sigma) (term/subst y sigma)]
+
+    [:t-refl x]
+    [:t-refl (term/subst x sigma)]
+
+    [:t-J A x P d y p]
+    [:t-J (term/subst A sigma)
+          (term/subst x sigma)
+          (term/subst P sigma)
+          (term/subst d sigma)
+          (term/subst y sigma)
+          (term/subst p sigma)]
+
+    _ tm))
+
+(defn- build-ctor-env [core-decls]
+  (let [ctors @{}
+        ctor-name-set @{}]
+    (each decl core-decls
+      (match decl
+        [:core/data data-name _ _ data-ctors]
+        (each ctor data-ctors
+          (put ctors (ctor 1) {:data data-name :ctor ctor})
+          (put ctor-name-set (ctor 1) true))
+        _ nil))
+    {:ctors ctors :ctor-name-set ctor-name-set}))
+
+(defn- check/with-ctors [Γ tm expected-core ctor-env]
+  (let [[head args] (term/spine tm)
+        info (and head (get (ctor-env :ctors) head))]
+    (if (nil? info)
+      (tt/check Γ tm (tt/eval Γ expected-core))
+      (let [[exp-head exp-args] (term/spine expected-core)]
+        (if (or (nil? exp-head) (not= exp-head (info :data)))
+          (tt/check Γ tm (tt/eval Γ expected-core))
+          (let [ctor (info :ctor)
+                patterns (ctor 3)
+                result (if (zero? (length patterns))
+                         (mt/outcome/yes (mt/subst/empty))
+                         (mt/matches* exp-args patterns (ctor-env :ctor-name-set) (mt/subst/empty)))]
+            (if (mt/outcome/yes? result)
+              (let [sigma (mt/outcome/subst result)
+                    params (ctor 4)]
+                (when (not= (length args) (length params))
+                  (errorf "constructor %v expects %d argument(s), got %d"
+                          head
+                          (length params)
+                          (length args)))
+                (for i 0 (length params)
+                  (let [arg (args i)
+                        param-ty (term/subst ((params i) 2) sigma)]
+                    (check/with-ctors Γ arg param-ty ctor-env)))
+                true)
+              (tt/check Γ tm (tt/eval Γ expected-core)))))))))
 
 (defn run/file-surface [path]
   (def start (os/clock))
@@ -30,6 +175,41 @@
     (print "  - " (decl/summary decl)))
   (def core (e/elab/program lowered))
   (print "Elaborated core declarations: " (length core))
+  (def global-ctx (build-global-ctx core))
+  (def ctor-env (build-ctor-env core))
+  (array/clear tt/goals) # Reset goals
+  (tt/goals/set-collect! true)
+  (each decl core
+    (match decl
+      [:core/func name params result ty clauses]
+      (do
+        (let [Γ (binders->ctx params global-ctx)
+              expected result]
+          (each c clauses
+            (check/with-ctors Γ (c 2) expected ctor-env))))
+
+      [:core/compute tm]
+      (do
+        (printf "\nCompute: %v" tm)
+        (let [res (tt/nf (tt/ty/type 100) tm)]
+          (printf "  => %s" (tt/nf/print res))))
+      [:core/check tm ty]
+      (do
+        (printf "\nCheck: %v : %v" tm ty)
+        (check/with-ctors global-ctx tm ty ctor-env)
+        (print "  => OK"))
+      _ nil))
+  (tt/goals/set-collect! false)
+  
+  (let [pending tt/goals]
+    (when (> (length pending) 0)
+      (print "\nPending Goals:")
+      (each g pending
+        (printf "  ?%v : %s" (g :name) (tt/nf/print (g :expected)))
+        (each c (g :ctx)
+          (printf "    %v : %s" (c 0) (tt/nf/print (c 1)))))))
+
+  (print "")
   (def elapsed (- (os/clock) start))
   (printf "Done. %d declaration(s) in %.3fs" (length lowered) elapsed))
 

--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -22,38 +22,25 @@
 (def NF/Id 0x4000)
 (def NF/Refl 0x8000)
 
-# Semantic values:
-#   [T/Type l]           - universes
-#   function            - Pi types (HOAS)
-#   [v1 v2]             - Sigma types (pairs)
-#   [T/Id A x y]        - Identity type
-#   [T/Refl x]          - Reflexivity proof
-#   [T/Neutral ne]      - stuck terms
+# Local level operations (workaround for import issues)
+(defn- lvl/const? [l] (and (tuple? l) (= (get l 0) 0x01)))
+(defn- lvl/shift? [l] (and (tuple? l) (= (get l 0) 0x02)))
+(defn- lvl/value [l]
+  (cond
+    (int? l) l
+    (lvl/const? l) (get l 1)
+    (lvl/shift? l) (get l 1)
+    true 0))
 
-# Normal forms:
-#   [NF/Lam body]        - lambda abstraction
-#   [NF/Pair l r]        - pair
-#   [NF/Type l]          - type universe
-#   [NF/Pi A B]          - Pi type
-#   [NF/Sigma A B]       - Sigma type
-#   [NF/Id A x y]        - Identity type
-#   [NF/Refl x]          - Reflexivity
-#   [NF/Neut ne]         - neutral term
-
-# Neutral terms:
-#   [:nvar x]           - variable
-#   [:napp f x]         - application
-#   [:nfst p]           - first projection
-#   [:nsnd p]           - second projection
-#   [:nJ A x P d y p]   - J eliminator (stuck)
-# (Keywords kept for AST readability)
-
-(import ./levels :as lvl)
+(defn- lvl/<= [l1 l2] (<= (lvl/value l1) (lvl/value l2)))
+(defn- lvl/eq? [l1 l2] (= (lvl/value l1) (lvl/value l2)))
+(defn- lvl/succ [l] (inc (lvl/value l)))
+(defn- lvl/max [l1 l2] (max (lvl/value l1) (lvl/value l2)))
 
 # ---------------------
 # Type constructors
 # ---------------------
-(defn ty/type [lvl] [T/Type (lvl/lvl/value lvl)])
+(defn ty/type [lvl] [T/Type (lvl/value lvl)])
 (defn ty/pi [A B] [T/Pi A B])
 (defn ty/sigma [A B] [T/Sigma A B])
 (defn ty/id [A x y] [T/Id A x y])
@@ -206,7 +193,7 @@
         t2 (if (tuple? v2) (get v2 0) 0)]
     (cond
       (and (= t1 T/Type) (= t2 T/Type))
-      (lvl/lvl/eq? (get v1 1) (get v2 1))
+      (lvl/eq? (get v1 1) (get v2 1))
 
       (and (= t1 T/Pi) (= t2 T/Pi))
       (let [[_ A1 B1] v1 [_ A2 B2] v2]
@@ -428,7 +415,7 @@
              tagB (if (tuple? B) (get B 0) 0)]
          (cond
            (and (= tagA T/Type) (= tagB T/Type))
-           (lvl/lvl/<= (get A 1) (get B 1))
+           (lvl/<= (get A 1) (get B 1))
 
            (and (= tagA T/Pi) (= tagB T/Pi))
            (let [[_ A1 B1] A
@@ -454,16 +441,37 @@
 (defn goal/context-vars [Γ]
   (map keyword (h/keys Γ)))
 
+(def goals @[])
+(var goals/collect? false)
+
+(defn goals/set-collect! [enabled]
+  (set goals/collect? enabled)
+  goals/collect?)
+
+(defn goal/report [name expected Γ]
+  (let [goal {:name name
+              :expected (lower (ty/type 100) expected)
+              :ctx (map (fn [k] [k (lower (ty/type 100) (ctx/lookup Γ k))]) (h/keys Γ))}]
+    (array/push goals goal)))
+
 (defn goal/error-infer [name Γ]
-  (errorf "unsolved goal ?%v during inference\nNo expected type is available in inference mode.\nContext variables: %v"
-          name
-          (goal/context-vars Γ)))
+  (if goals/collect?
+    (do
+      (goal/report name (ty/type 100) Γ)
+      [:type 100])
+    (errorf "unsolved goal ?%v during inference\nNo expected type is available in inference mode.\nContext variables: %v"
+            name
+            (goal/context-vars Γ))))
 
 (defn goal/error-check [name expected Γ]
-  (errorf "unsolved goal ?%v during checking\nExpected type: %v\nContext variables: %v"
-          name
-          expected
-          (goal/context-vars Γ)))
+  (if goals/collect?
+    (do
+      (goal/report name expected Γ)
+      true)
+    (errorf "unsolved goal ?%v during checking\nExpected type: %v\nContext variables: %v"
+            name
+            expected
+            (goal/context-vars Γ))))
 
 (set infer
      (fn [Γ t]
@@ -474,7 +482,7 @@
            (ctx/lookup Γ x)
             (errorf "variable must be a string or symbol, but got: %v\nVariable names should be like 'x', 'y', 'myVar', etc." x))
 
-          [:type l] (ty/type (lvl/lvl/succ l))
+          [:type l] (ty/type (lvl/succ l))
 
           [:lam _] (errorf "cannot infer type of lambda expression %v\nLambda types require annotation because they have principal types.\nSuggestion: Annotate with a Pi type: (λx. body) : (Πx:A. B)" t)
 
@@ -496,7 +504,7 @@
                 A-sem (eval Γ A)
                 Γ2 (ctx/add Γ fresh A-sem)
                 lvlB (check-univ Γ2 (B [:var fresh]))]
-            (ty/type (lvl/lvl/max lvlA lvlB)))
+            (ty/type (lvl/max lvlA lvlB)))
 
           [:t-sigma A B]
           (let [lvlA (check-univ Γ A)
@@ -504,7 +512,7 @@
                 A-sem (eval Γ A)
                 Γ2 (ctx/add Γ fresh A-sem)
                 lvlB (check-univ Γ2 (B [:var fresh]))]
-            (ty/type (lvl/lvl/max lvlA lvlB)))
+            (ty/type (lvl/max lvlA lvlB)))
 
          [:fst p]
          (let [pA (infer Γ p)
@@ -574,7 +582,8 @@
 
 (set check
      (fn [Γ t A]
-       "Check that term t has type A in context Γ"
+       #"Check that term t has type A in context Γ"
+       #(printf "CHECK: %v : %v" t A)
         (match t
           [:hole name]
           (goal/error-check name A Γ)
@@ -625,6 +634,30 @@
 (defn infer-top [t]
   (let [Γ (ctx/empty)]
     (infer Γ t)))
+
+(var ne/print nil)
+(var nf/print nil)
+
+(set ne/print (fn [ne]
+  (match ne
+    [:nvar x] (string x)
+    [:napp f x] (string "(" (ne/print f) " " (nf/print x) ")")
+    [:nfst p] (string "fst(" (ne/print p) ")")
+    [:nsnd p] (string "snd(" (ne/print p) ")")
+    [:nJ A x P d y p] (string "J(" (nf/print A) ", " (nf/print x) ", " (nf/print P) ", " (nf/print d) ", " (nf/print y) ", " (ne/print p) ")")
+    _ (string/format "%v" ne))))
+
+(set nf/print (fn [nf]
+  (match nf
+    [NF/Type l] (string "Type" (if (or (int? l) (tuple? l)) (lvl/value l) (string/format "%v" l)))
+    [NF/Pi A B] (string "Π(" (nf/print A) ", " (nf/print B) ")")
+    [NF/Sigma A B] (string "Σ(" (nf/print A) ", " (nf/print B) ")")
+    [NF/Id A x y] (string "Id(" (nf/print A) ", " (nf/print x) ", " (nf/print y) ")")
+    [NF/Refl x] (string "refl(" (nf/print x) ")")
+    [NF/Pair l r] (string "(" (nf/print l) ", " (nf/print r) ")")
+    [NF/Lam _] (string "λ. ...") # HOAS is hard to print without name recovery
+    [NF/Neut ne] (ne/print ne)
+    _ (string/format "%v" nf))))
 
 # Public API
 (def exports
@@ -688,4 +721,8 @@
    :ctx/empty ctx/empty
    :ctx/add ctx/add
    :ctx/lookup ctx/lookup
-   :eval/session eval/session})
+   :eval/session eval/session
+    :nf/print nf/print
+    :ne/print ne/print
+    :goals goals
+    :goals/set-collect! goals/set-collect!})

--- a/src/elab.janet
+++ b/src/elab.janet
@@ -322,14 +322,26 @@
 (set elab/term
      (fn [env sig-env node]
        (match node
-         [:atom tok]
-         (elab/atom env sig-env tok true)
+         [:atom tok] (elab/atom env sig-env tok true)
+         [:nat n] [:var (string n)]
+         [:list xs] (elab/list env sig-env node xs)
 
-          [:list xs]
-          (elab/list env sig-env node xs)
+         # Surface AST nodes
+         [:ty/universe lvl _] [:type lvl]
+         [:ty/hole name _] [:hole name]
+         [:ty/var x _] (elab/atom env sig-env x true)
+         [:ty/name x _] (elab/atom env sig-env x true)
+         [:ty/arrow dom cod _] [:t-pi (elab/term env sig-env dom) (fn [_] (elab/term env sig-env cod))]
+         [:ty/app f a _] [:app (elab/term env sig-env f) (elab/term env sig-env a)]
+         
+         [:tm/nat n _] [:var (string n)]
+         [:tm/var x _] (elab/atom env sig-env x true)
+         [:tm/ref x _] (elab/atom env sig-env x true)
+         [:tm/hole name _] [:hole name]
+         [:tm/app f a _] [:app (elab/term env sig-env f) (elab/term env sig-env a)]
+         [:tm/lam params body _] (elab/lam-chain env sig-env params body)
 
-          _
-          (errorf "cannot elaborate node: %v" node))))
+         _ (errorf "cannot elaborate node: %v" node))))
 
 (defn binders/elab [env sig-env binders]
   (let [[out final-env]
@@ -742,8 +754,16 @@
           core-ctors (map (fn [ctor]
                             (match ctor
                               [:ctor ctor-name pat-binders patterns ctor-params encoded-type _]
-                              [:core/ctor ctor-name pat-binders patterns ctor-params
-                               (elab/term env sig-env encoded-type)]
+                              [:core/ctor ctor-name
+                               pat-binders
+                               patterns
+                               (map (fn [b]
+                                      (match b
+                                        [:bind bname bty]
+                                        [:bind bname (elab/term env sig-env bty)]
+                                        _ (errorf "invalid ctor parameter binder: %v" b)))
+                                    ctor-params)
+                                (elab/term env sig-env encoded-type)]
                               _ (errorf "invalid constructor: %v" ctor)))
                           ctors)]
       [:core/data name core-params core-sort core-ctors])
@@ -754,6 +774,12 @@
           core-type (elab/pi-chain @[] sig-env params result)
           core-clauses (map |(clause/elab env sig-env $) clauses)]
       [:core/func name core-params core-result core-type core-clauses])
+
+    [:decl/compute tm]
+    [:core/compute (elab/term @[] sig-env tm)]
+
+    [:decl/check tm ty]
+    [:core/check (elab/term @[] sig-env tm) (elab/term @[] sig-env ty)]
 
     _
     (errorf "invalid declaration: %v" decl)))

--- a/src/frontend/surface/ast.janet
+++ b/src/frontend/surface/ast.janet
@@ -81,6 +81,8 @@
 
 (defn decl/data [name params ctors sp] [:decl/data name params ctors sp])
 (defn decl/func [name ty clauses sp] [:decl/func name ty clauses sp])
+(defn decl/compute [tm sp] [:decl/compute tm sp])
+(defn decl/check [tm ty sp] [:decl/check tm ty sp])
 (defn program [decls sp] [:program decls sp])
 
 (defn node/tag [node] (if (tuple? node) (node 0) nil))
@@ -112,6 +114,9 @@
     (or (= t :tm/hole) (= t :tm/var) (= t :tm/ref) (= t :tm/nat)
         (= t :tm/app) (= t :tm/lam) (= t :tm/let) (= t :tm/op))))
 
+(defn node/type-or-term? [n]
+  (or (node/type? n) (node/term? n)))
+
 (defn node/pat? [n]
   (let [t (node/tag n)]
     (or (= t :pat/wild) (= t :pat/hole) (= t :pat/var)
@@ -119,7 +124,8 @@
 
 (defn node/decl? [n]
   (let [t (node/tag n)]
-    (or (= t :decl/prec) (= t :decl/data) (= t :decl/func))))
+    (or (= t :decl/prec) (= t :decl/data) (= t :decl/func)
+        (= t :decl/compute) (= t :decl/check))))
 
 (def exports
   {:ast/debug-checks? ast/debug-checks?
@@ -161,6 +167,8 @@
    :decl/prec decl/prec
    :decl/data decl/data
    :decl/func decl/func
+   :decl/compute decl/compute
+   :decl/check decl/check
    :program program
    :node/tag node/tag
    :node/span node/span

--- a/src/frontend/surface/decls.janet
+++ b/src/frontend/surface/decls.janet
@@ -16,6 +16,44 @@
       :op (capture (thru -1))
       :main (* :ws* :fix :ws+ :lvl :ws+ :op :ws*)}))
 
+(def peg/alias-line
+  (peg/compile
+    ~{:ws* (any (set " \t"))
+      :ws+ (some (set " \t"))
+      :ident (capture (some (if-not (set " \t=") 1)))
+      :main (* :ws* "alias" :ws+ :ident :ws* "=" :ws* :ident :ws*)}))
+
+(def peg/import-line
+  (peg/compile
+    ~{:ws* (any (set " \t"))
+      :ws+ (some (set " \t"))
+      :path (capture (+ (* "\"" (some (if-not "\"" 1)) "\"")
+                        (some (if-not (set " \t") 1))))
+      :main (* :ws* "import" :ws+ :path :ws*)}))
+
+(def peg/compute-line
+  (peg/compile
+    ~{:ws* (any (set " \t"))
+      :ws+ (some (set " \t"))
+      :tm (capture (thru -1))
+      :main (* :ws* "compute" :ws+ :tm :ws*)}))
+
+(def peg/check-line
+  (peg/compile
+    ~{:ws* (any (set " \t"))
+      :ws+ (some (set " \t"))
+      :tm (capture (some (if-not (set ":") 1)))
+      :ty (capture (thru -1))
+      :main (* :ws* "check" :ws+ :tm :ws* ":" :ws* :ty :ws*)}))
+
+(def peg/split-eq-line
+  (peg/compile
+    ~{:ws* (any (set " \t"))
+      :ws+ (some (set " \t"))
+      :lhs (capture (any (if-not "=" 1)))
+      :rhs (capture (thru -1))
+      :main (* :ws* :lhs "=" :rhs)}))
+
 (defn- is-upper-byte? [c]
   (and (>= c (chr "A")) (<= c (chr "Z"))))
 
@@ -26,7 +64,6 @@
   (or (is-upper-byte? c) (is-lower-byte? c) (= c (chr "_"))))
 
 (defn- find-top-level-colon [text]
-  "Find the index of the last top-level colon respecting balanced parens."
   (let [n (length text)]
     (var depth 0)
     (var last-colon nil)
@@ -40,40 +77,54 @@
     last-colon))
 
 (defn- extract-name-and-params [lhs]
-  "From 'Name' or 'Name(params)', extract [name params-text-or-nil]."
-  (let [t (ly/trim lhs)
-        paren-idx (string/find "(" t)]
-    (if (and paren-idx
-             (string/has-suffix? ")" t))
-      [(string/slice t 0 paren-idx)
-       (string/slice t (+ paren-idx 1) (- (length t) 1))]
-      [t nil])))
+  (if-let [lp (string/find "(" lhs)]
+    (let [name (ly/trim (string/slice lhs 0 lp))
+          params (string/slice lhs (+ lp 1) (- (length lhs) 1))]
+      [name params])
+    [(ly/trim lhs) nil]))
 
-(def peg/split-eq-line
-  (peg/compile
-    ~{:ws* (any (set " \t"))
-      :lhs (capture (some (if-not "=" 1)))
-      :rhs (capture (thru -1))
-      :main (* :lhs :ws* "=" :ws* :rhs)}))
+(defn read-parenthesized-end [text start]
+  (let [n (length text)]
+    (var depth 0)
+    (var i start)
+    (var found false)
+    (while (and (< i n) (not found))
+      (let [c (text i)]
+        (cond
+          (= c (chr "(")) (++ depth)
+          (= c (chr ")")) (do
+                          (-- depth)
+                          (when (= depth 0)
+                            (set found true)
+                            (++ i)))
+          true (++ i))))
+    (if found i nil)))
 
-(defn- indent/tokenize [src]
-  (let [lines (string/split "\n" src)
-        out @[]]
-    (for i 0 (length lines)
-      (let [line (ly/trimr (lines i))
-            lnum (+ i 1)
-            left (ly/triml line)]
-        (when (and (not= left "")
-                   (not (string/has-prefix? "--" left)))
-          (var col 0)
-          (while (and (< col (length line)) (= (line col) (chr " "))) (++ col))
-          (array/push out {:line lnum :col col :text (string/slice line col)}))))
-    out))
+(defn- parse/field-fragment [text syntax mk-named mk-anon]
+  (let [colon-ix (find-top-level-colon text)]
+    (if colon-ix
+      (let [name (ly/trim (string/slice text 0 colon-ix))
+            ty-text (ly/trim (string/slice text (+ colon-ix 1)))]
+        (mk-named name (pr/parse/type-text ty-text syntax) (a/span/none)))
+      (mk-anon (pr/parse/type-text text syntax) (a/span/none)))))
 
-(defn- parse/type-params [params-text prec syntax]
-  (if (or (nil? params-text) (= (ly/trim params-text) ""))
+(defn parse/fields [text syntax mk-named mk-anon]
+  (if (or (nil? text) (= text ""))
     @[]
-    (let [parts (ly/split-top-level params-text (chr ","))
+    (let [parts (ly/split-top-level text (chr ","))
+          out @[]]
+      (each p parts
+        (let [trimmed (ly/trim p)]
+          (when (not= trimmed "")
+            (if (and (string/has-prefix? "(" trimmed) (string/has-suffix? ")" trimmed))
+              (array/push out (parse/field-fragment (string/slice trimmed 1 -2) syntax mk-named mk-anon))
+              (array/push out (parse/field-fragment trimmed syntax mk-named mk-anon))))))
+      out)))
+
+(defn- parse/type-params [text syntax]
+  (if (or (nil? text) (= (ly/trim text) ""))
+    @[]
+    (let [parts (ly/split-top-level text (chr ","))
           out @[]]
       (each p parts
         (let [x (ly/trim p)]
@@ -81,70 +132,29 @@
             (if-let [ix (ly/find-top-level-char x (chr ":"))]
               (array/push out
                           (a/decl/param (ly/trim (string/slice x 0 ix))
-                                        (pr/parse/type-text (string/slice x (+ ix 1)) prec syntax)
+                                        (pr/parse/type-text (ly/trim (string/slice x (+ ix 1))) syntax)
                                         (a/span/none)))
               (array/push out (a/decl/param x nil (a/span/none)))))))
       out)))
 
-(defn- parse/field-fragment [frag prec syntax]
-  (let [t (ly/trim frag)
-        sp (a/span/none)]
-    (if-let [ix (ly/find-top-level-char t (chr ":"))]
-      (a/decl/field-named (ly/trim (string/slice t 0 ix))
-                          (pr/parse/type-text (string/slice t (+ ix 1)) prec syntax)
-                          sp)
-      (a/decl/field-anon (pr/parse/type-text t prec syntax) sp))))
+(defn- parse/ctor-rhs [rhs syntax]
+  (let [trimmed (ly/trim rhs)]
+    (if (= trimmed "()")
+      [nil @[]]
+      (if-let [lp (string/find "(" trimmed)]
+        (let [name (ly/trim (string/slice trimmed 0 lp))
+              rest (string/slice trimmed (+ lp 1) (- (length trimmed) 1))]
+          [name (parse/fields rest syntax a/decl/field-named a/decl/field-anon)])
+        (let [parts (ly/split-ws-top-level trimmed)]
+          (when (zero? (length parts))
+            (error "empty constructor rhs"))
+          (let [name (ly/trim (parts 0))
+                rest (if (> (length parts) 1)
+                       (string/slice trimmed (+ (length (parts 0)) 1))
+                       "")]
+            [name (parse/fields rest syntax a/decl/field-named a/decl/field-anon)]))))))
 
-(defn- read-parenthesized-end [text start]
-  (let [n (length text)]
-    (var i start)
-    (var depth 0)
-    (var found false)
-    (var result nil)
-    (while (and (< i n) (not found))
-      (let [c (text i)]
-        (cond
-          (= c (chr "(")) (++ depth)
-          (= c (chr ")")) (when (> depth 0) (-- depth)))
-        (++ i)
-        (when (= depth 0)
-          (set found true)
-          (set result i))))
-    result))
-
-(defn- parse/fields [text prec syntax]
-  (let [out @[]
-        n (length text)]
-    (var i 0)
-    (while (< i n)
-      (while (and (< i n) (lx/is-space-byte? (text i))) (++ i))
-      (when (< i n)
-        (if (= (text i) (chr "("))
-          (if-let [end (read-parenthesized-end text i)]
-            (do
-              (array/push out
-                          (parse/field-fragment
-                            (string/slice text (+ i 1) (- end 1))
-                            prec
-                            syntax))
-              (set i end))
-            (errorf "unclosed field paren: %v" text))
-          (let [start i]
-            (while (and (< i n) (not (lx/is-space-byte? (text i)))) (++ i))
-            (array/push out (parse/field-fragment (string/slice text start i) prec syntax))))))
-    out))
-
-(defn- parse/ctor-rhs [rhs prec syntax]
-  (let [parts (ly/split-ws-top-level rhs)]
-    (when (zero? (length parts))
-      (error "empty constructor rhs"))
-    (let [name (ly/trim (parts 0))
-          rest (if (> (length parts) 1)
-                 (string/slice rhs (+ (length (parts 0)) 1))
-                 "")]
-      [name (parse/fields rest prec syntax)])))
-
-(defn- parse/data-body-line [text prec syntax]
+(defn- parse/data-body-line [text syntax]
   (if-let [eq (peg/match peg/split-eq-line text)]
     (let [lhs (ly/trim (eq 0))
           rhs (ly/trim (eq 1))
@@ -152,156 +162,175 @@
           indices @[]]
       (each p idx-parts
         (array/push indices (pat/parse/pat-text p)))
-      (let [[name fields] (parse/ctor-rhs rhs prec syntax)]
-        (a/decl/ctor-indexed indices name fields (a/span/none))))
-    (let [[name fields] (parse/ctor-rhs (ly/trim text) prec syntax)]
-      (a/decl/ctor-plain name fields (a/span/none)))))
+      (let [[name fields] (parse/ctor-rhs rhs syntax)]
+        (if name
+          [(a/decl/ctor-indexed indices name fields (a/span/none))]
+          [])))
+    (let [[name fields] (parse/ctor-rhs (ly/trim text) syntax)]
+      (if name
+        [(a/decl/ctor-plain name fields (a/span/none))]
+        []))))
 
-(defn- parse/term-body-line [text prec syntax]
-  (print "Parsing clause: " text)
+(defn- parse/term-body-line [text syntax]
   (if-let [eq (peg/match peg/split-eq-line text)]
     (let [lhs (ly/trim (eq 0))
           rhs (ly/trim (eq 1))
           pats @[]]
       (each part (ly/split-ws-top-level lhs)
         (array/push pats (pat/parse/pat-text part)))
-      (a/decl/clause pats (pr/parse/expr-text rhs prec syntax) (a/span/none)))
+      (a/decl/clause pats (pr/parse/expr-text rhs syntax) (a/span/none)))
     (errorf "invalid clause line: %v" text)))
 
 (defn- classify-top [text]
-  (if-let [m (peg/match peg/prec-line text)]
-    [:top/prec (m 0) (scan-number (ly/trim (m 1))) (ly/trim (m 2))]
-    (if-let [colon-idx (find-top-level-colon text)]
-      (let [lhs (ly/trim (string/slice text 0 colon-idx))
-            rhs (ly/trim (string/slice text (+ colon-idx 1)))
-            [name params-text] (extract-name-and-params lhs)]
-        (if (and (> (length name) 0) (is-upper-byte? (name 0)))
-          [:top/type-head name params-text rhs]
-          [:top/term-head name params-text rhs]))
-      (errorf "unknown top-level line (no colon found): %v" text))))
+  (if (string/has-prefix? "#" (ly/trim text))
+    [:top/comment]
+    (if-let [m (peg/match peg/prec-line text)]
+      [:top/prec (m 0) (scan-number (ly/trim (m 1))) (ly/trim (m 2))]
+      (if-let [m (peg/match peg/alias-line text)]
+        [:top/alias (m 0) (m 1)]
+        (if-let [m (peg/match peg/import-line text)]
+          [:top/import (m 0)]
+          (if-let [m (peg/match peg/compute-line text)]
+            [:top/compute (m 0)]
+            (if-let [m (peg/match peg/check-line text)]
+              [:top/check (m 0) (m 1)]
+              (if-let [colon-idx (find-top-level-colon text)]
+                (let [lhs (ly/trim (string/slice text 0 colon-idx))
+                      rhs (ly/trim (string/slice text (+ colon-idx 1)))
+                      [name params-text] (extract-name-and-params lhs)]
+                  (if (and (> (length name) 0) (is-upper-byte? (name 0)))
+                    [:top/type-head name params-text rhs]
+                    [:top/term-head name params-text rhs]))
+                (errorf "unknown top-level line (no colon found): %v" text)))))))))
 
-(defn- build-prec-table [entries]
-  (let [prec @{}]
-    (each e entries
-      (when (= (e :kind) :prec)
-        (put prec (e :op) {:fixity (e :fixity) :level (e :level)})))
-    prec))
+(var parse/source nil)
 
-(defn parse/source [src &opt syntax]
-  (def syn (or syntax (sx/syntax/default)))
-  (let [lines (indent/tokenize src)
-        entries @[]]
-    (var current nil)
+(set parse/source
+     (fn [src &opt syntax]
+       (let [syn (or syntax (sx/syntax/default))
+             lines (ly/indent/tokenize src)
+             decls @[]]
+         (var current nil)
 
-    (defn flush-current []
-      (when current
-        (array/push entries current)
-        (set current nil)))
+         (defn flush-current []
+           (when current
+             (match (current :kind)
+               :data-head
+               (let [params (parse/type-params (current :params-text) syn)
+                      ctors @[]]
+                 (each bl (current :body)
+                   (let [new-ctors (parse/data-body-line bl syn)]
+                     (each c new-ctors (array/push ctors c))))
+                 (array/push decls (a/decl/data (current :name) params ctors (a/span/none))))
 
-    (each ln lines
-      (if (= (ln :col) 0)
-        (do
-          (flush-current)
-          (let [top (classify-top (ln :text))]
-            (match (top 0)
-              :top/prec
-              (let [fx (match (top 1)
-                         "infixl" :infixl
-                         "infixr" :infixr
-                         "prefix" :prefix
-                         "postfix" :postfix
-                         (errorf "unknown fixity %v" (top 1)))]
-                (array/push entries {:kind :prec
-                                     :fixity fx
-                                     :level (top 2)
-                                     :op (top 3)}))
+               :term-head
+               (let [body-lines (current :body)
+                     type-parts @[]
+                     clause-lines @[]
+                     _ (do
+                         (var found-clause false)
+                         (each bl body-lines
+                           (if found-clause
+                             (array/push clause-lines bl)
+                             (if (peg/match peg/split-eq-line bl)
+                               (do (set found-clause true)
+                                   (array/push clause-lines bl))
+                               (array/push type-parts bl)))))
+                     head-type (or (current :type-text) "")
+                     full-type-text (if (or (zero? (length type-parts)) (= (string/trim (string/join type-parts "")) ""))
+                                     (if (and head-type (not= (string/trim head-type) "")) head-type "?")
+                                     (string head-type " " (string/join type-parts " ")))
+                     params-text (current :params-text)
+                     # Weave params into type as Pi binders
+                     final-type-text
+                     (if (and params-text (not= params-text ""))
+                       (let [param-parts (ly/split-top-level params-text (chr ","))
+                             pi-prefix @[]]
+                         (each pp param-parts
+                           (let [tp (ly/trim pp)]
+                             (when (not= tp "")
+                               (if-let [colon-ix (ly/find-top-level-char tp (chr ":"))]
+                                 (let [names-part (ly/trim (string/slice tp 0 colon-ix))
+                                       ty-part (ly/trim (string/slice tp (+ colon-ix 1)))
+                                       names (ly/split-top-level names-part (chr ","))]
+                                   (each nm names
+                                     (let [n (ly/trim nm)]
+                                       (when (not= n "")
+                                         (array/push pi-prefix (string "Pi(" n ": " ty-part "). "))))))
+                                 (array/push pi-prefix (string "Pi(" tp ": Type). "))))))
+                         (string (string/join pi-prefix "") full-type-text))
+                       full-type-text)
+                     ty (pr/parse/type-text final-type-text syn)
+                     clauses @[]]
+                 (each cl clause-lines
+                   (array/push clauses (parse/term-body-line cl syn)))
+                 (array/push decls (a/decl/func (current :name) ty clauses (a/span/none)))))
+             (set current nil)))
 
-              :top/type-head
-              (set current {:kind :data-head
-                            :name (top 1)
-                            :params-text (top 2)
-                            :sort-text (top 3)
-                            :body @[]})
+         (each ln lines
+           (if (= (ln :col) 0)
+             (do
+               (let [top (classify-top (ln :text))]
+                 (match (top 0)
+                   :top/comment nil
+                   _ (do
+                       (flush-current)
+                       (match (top 0)
+                         :top/prec
+                         (let [fx (match (top 1)
+                                    "infixl" :infixl
+                                    "infixr" :infixr
+                                    "prefix" :prefix
+                                    "postfix" :postfix
+                                    (errorf "unknown fixity %v" (top 1)))]
+                           (sx/syntax/add-operator! syn (top 3) fx (top 2)))
 
-              :top/term-head
-              (set current {:kind :term-head
-                            :name (top 1)
-                            :params-text (top 2)
-                            :type-text (top 3)
-                            :body @[]}))))
-        (if current
-          (array/push (current :body) (ln :text))
-          (errorf "indented line without declaration: %v" (ln :text)))))
+                         :top/alias
+                         (sx/syntax/add-alias! syn (top 1) (top 2))
 
-    (flush-current)
+                         :top/import
+                         (let [path (top 1)
+                               q "\""
+                               path (if (and (string/has-prefix? q path) (string/has-suffix? q path))
+                                      (string/slice path 1 -2)
+                                      path)
+                               ext (if (string/has-suffix? ".requiem" path) "" ".requiem")
+                               full-path (string path ext)
+                               content (if (os/stat full-path) (slurp full-path) nil)]
+                           (if content
+                             (let [prog (parse/source (string content) syn)
+                                   ds (prog 1)]
+                               (each d ds (array/push decls d)))
+                             (errorf "could not import file: %v" full-path)))
 
-    (let [prec (build-prec-table entries)
-          decls @[]]
-      (each e entries
-        (match (e :kind)
-          :prec
-          (array/push decls (a/decl/prec (e :fixity) (e :level) (e :op) (a/span/none)))
+                         :top/compute
+                         (array/push decls (a/decl/compute (pr/parse/expr-text (top 1) syn) (a/span/none)))
 
-          :data-head
-          (let [params (parse/type-params (e :params-text) prec syn)
-                ctors @[]]
-            (each bl (e :body)
-              (array/push ctors (parse/data-body-line bl prec syn)))
-            (array/push decls (a/decl/data (e :name) params ctors (a/span/none))))
+                         :top/check
+                         (array/push decls (a/decl/check (pr/parse/expr-text (top 1) syn)
+                                                         (pr/parse/type-text (top 2) syn)
+                                                         (a/span/none)))
 
-          :term-head
-          (let [# Separate body into type-continuation lines and clause lines
-                # Lines without '=' before the first clause line are type continuation
-                body-lines (e :body)
-                type-parts @[]
-                clause-lines @[]
-                _ (do
-                    (var found-clause false)
-                    (each bl body-lines
-                      (if found-clause
-                        (array/push clause-lines bl)
-                        (if (peg/match peg/split-eq-line bl)
-                          (do (set found-clause true)
-                              (array/push clause-lines bl))
-                          (array/push type-parts bl)))))
-                # Build full type text: head type-text + continuation lines + params
-                head-type (or (e :type-text) "")
-                full-type-text
-                (if (zero? (length type-parts))
-                  head-type
-                  (string head-type
-                          (if (> (length head-type) 0) " " "")
-                          (string/join type-parts " ")))
-                # Weave params into type as Pi binders
-                params-text (e :params-text)
-                final-type-text
-                (if params-text
-                  (let [param-parts (ly/split-top-level params-text (chr ","))
-                        pi-prefix @[]]
-                    (each pp param-parts
-                      (let [tp (ly/trim pp)]
-                        (when (not= tp "")
-                          (if-let [colon-ix (ly/find-top-level-char tp (chr ":"))]
-                            # Split on colon: could be "n,m: Nat" or "A: Type"
-                            (let [names-part (ly/trim (string/slice tp 0 colon-ix))
-                                  ty-part (ly/trim (string/slice tp (+ colon-ix 1)))
-                                  names (ly/split-top-level names-part (chr ","))]
-                              (each nm names
-                                (let [n (ly/trim nm)]
-                                  (when (not= n "")
-                                    (array/push pi-prefix
-                                                (string "\xCE\xA0(" n ": " ty-part "). "))))))
-                            (array/push pi-prefix (string "\xCE\xA0(" tp ": Type). "))))))
-                    (string (string/join pi-prefix "") full-type-text))
-                  full-type-text)
-                ty (pr/parse/type-text final-type-text prec syn)
-                clauses @[]]
-            (each cl clause-lines
-              (array/push clauses (parse/term-body-line cl prec syn)))
-            (array/push decls (a/decl/func (e :name) ty clauses (a/span/none))))
+                         :top/type-head
+                         (set current {:kind :data-head
+                                       :name (top 1)
+                                       :params-text (top 2)
+                                       :sort-text (top 3)
+                                       :body @[]})
 
-          _ (errorf "unknown entry kind: %v" (e :kind))))
-      (a/program decls (a/span/none)))))
+                         :top/term-head
+                         (set current {:kind :term-head
+                                       :name (top 1)
+                                       :params-text (top 2)
+                                       :type-text (top 3)
+                                       :body @[]}))))))
+             (if current
+               (array/push (current :body) (ln :text))
+               (when (not (string/has-prefix? "#" (ly/trim (ln :text))))
+                 (errorf "indented line without declaration: %v" (ln :text))))))
+
+         (flush-current)
+         (a/program decls (a/span/none)))))
 
 (def exports
   {:parse/source parse/source})

--- a/src/frontend/surface/layout.janet
+++ b/src/frontend/surface/layout.janet
@@ -70,6 +70,16 @@
     (++ i))
   result)
 
+(defn indent/tokenize [src]
+  (let [lines (string/split "\n" src)
+        out @[]]
+    (eachp [i line] lines
+      (let [trimmed (string/triml line)
+            col (- (length line) (length trimmed))]
+        (when (not= (trim line) "")
+          (array/push out @{:text trimmed :col col :line (+ i 1)}))))
+    out))
+
 (def exports
   {:trim trim
    :trimr trimr
@@ -77,4 +87,5 @@
    :is-space-byte? is-space-byte?
    :split-top-level split-top-level
    :split-ws-top-level split-ws-top-level
-   :find-top-level-char find-top-level-char})
+   :find-top-level-char find-top-level-char
+   :indent/tokenize indent/tokenize})

--- a/src/frontend/surface/lower.janet
+++ b/src/frontend/surface/lower.janet
@@ -216,6 +216,21 @@
     [:list xs] (lst @[;xs x])
     _ (lst @[f x])))
 
+(defn- term/render [node]
+  (match node
+    [:atom tok]
+    tok
+
+    [:list xs]
+    (string "(" (string/join (map term/render xs) " ") ")")
+
+    _
+    (string/format "%v" node)))
+
+(defn- term/equal? [a b]
+  (= (term/render a)
+     (term/render b)))
+
 (var lower/type nil)
 
 (defn- lower/binder [binder]
@@ -283,12 +298,17 @@
          (flatten-app (lower/term f) (lower/term x))
 
          [:tm/lam params body _sp]
-         (let [binder-nodes (map |(atom $) params)]
-           (lst @[(atom "fn")
-                  (if (= (length binder-nodes) 1)
-                    (binder-nodes 0)
-                    (lst binder-nodes))
-                  (lower/term body)]))
+         (let [lower-param (fn [p]
+                              (if (string? p)
+                                (atom p)
+                                (let [[_ name ty _] p]
+                                  (node/binder name (lower/type ty)))))
+                binder-nodes (map lower-param params)]
+            (lst @[(atom "fn")
+                   (if (= (length binder-nodes) 1)
+                     (binder-nodes 0)
+                     (lst binder-nodes))
+                   (lower/term body)]))
 
          [:tm/let name value body _sp]
          (lst @[(atom "let")
@@ -414,6 +434,26 @@
         encoded (ctor/ford-encoded data-name data-params pat-binders ctor-params eq-binders)]
     [:ctor name pat-binders patterns ctor-params encoded eq-binders]))
 
+(defn- ctor/drop-index-echo-fields [indices fields]
+  # Aya-style sugar: in indexed branches, ctor(arg) where arg repeats
+  # the branch index is treated as an index echo, not a runtime field.
+  (let [index-terms (map lower/pat-to-term indices)
+        n-fields (length fields)
+        n-index (length index-terms)]
+    (var fi 0)
+    (var ii 0)
+    (while (and (< fi n-fields) (< ii n-index))
+      (let [f (fields fi)]
+        (match f
+          [:field/anon ty _sp]
+          (if (term/equal? (lower/type ty) (index-terms ii))
+            (do (++ fi) (++ ii))
+            (break))
+
+          _
+          (break))))
+    (slice fields fi n-fields)))
+
 # ---------------------------------------------------------------
 # Constructor lowering (plain & indexed)
 # ---------------------------------------------------------------
@@ -432,7 +472,8 @@
 (defn- ctor/lower-indexed-ctor [data-name data-params ctor-node]
   (match ctor-node
     [:ctor/indexed indices name fields _sp]
-    (let [ctor-binders (lower/ctor-fields-as-binders fields)
+    (let [effective-fields (ctor/drop-index-echo-fields indices fields)
+          ctor-binders (lower/ctor-fields-as-binders effective-fields)
           ret-args (map lower/pat-to-term indices)]
       (if (args/simple-return? ret-args data-params)
         (let [data-param-terms (map |(atom ($ 1)) data-params)
@@ -529,6 +570,12 @@
           [lowered-params result] (split-pi lowered-ty)
           lowered-clauses (map |(lower/clause $ data-env lowered-params) clauses)]
       [:decl/func name lowered-params result lowered-clauses])
+
+    [:decl/compute tm _sp]
+    [:decl/compute (lower/term tm)]
+
+    [:decl/check tm ty _sp]
+    [:decl/check (lower/term tm) (lower/type ty)]
 
     _ (errorf "lower/decl: unknown declaration %v" decl)))
 

--- a/src/frontend/surface/parser.janet
+++ b/src/frontend/surface/parser.janet
@@ -2,86 +2,59 @@
 
 (import ./ast :as a)
 (import ./syntax :as x)
+(import ./lexer :as lx)
 (import ./pratt :as pr)
 (import ./patterns :as pat)
 (import ./decls :as d)
 (import ./lower :as lo)
 
-(def ast/debug-checks? a/ast/debug-checks?)
-(def ast/set-debug-checks! a/ast/set-debug-checks!)
+# ---------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------
 
-(def syntax/default x/syntax/default)
-(def syntax/clone x/syntax/clone)
-(def syntax/add-literal! x/syntax/add-literal!)
-(def syntax/add-quant-alias! x/syntax/add-quant-alias!)
-(def syntax/add-type-ident-resolver! x/syntax/add-type-ident-resolver!)
-
-(def pos a/pos)
-(def span a/span)
-(def span/none a/span/none)
-
-(def ty/hole a/ty/hole)
-(def ty/universe a/ty/universe)
-(def ty/name a/ty/name)
-(def ty/var a/ty/var)
-(def ty/app a/ty/app)
-(def ty/arrow a/ty/arrow)
-(def ty/binder a/ty/binder)
-(def ty/pi a/ty/pi)
-(def ty/forall a/ty/forall)
-(def ty/sigma a/ty/sigma)
-(def ty/exists a/ty/exists)
-(def ty/op a/ty/op)
-
-(def tm/hole a/tm/hole)
-(def tm/var a/tm/var)
-(def tm/ref a/tm/ref)
-(def tm/nat a/tm/nat)
-(def tm/app a/tm/app)
-(def tm/lam a/tm/lam)
-(def tm/let a/tm/let)
-(def tm/op a/tm/op)
-
-(def pat/wild a/pat/wild)
-(def pat/hole a/pat/hole)
-(def pat/var a/pat/var)
-(def pat/con a/pat/con)
-(def pat/nat a/pat/nat)
-
-(def decl/param a/decl/param)
-(def decl/field-named a/decl/field-named)
-(def decl/field-anon a/decl/field-anon)
-(def decl/ctor-plain a/decl/ctor-plain)
-(def decl/ctor-indexed a/decl/ctor-indexed)
-(def decl/clause a/decl/clause)
-(def decl/prec a/decl/prec)
-(def decl/data a/decl/data)
-(def decl/func a/decl/func)
-
-(def program a/program)
-
+# AST Nodes
 (def node/tag a/node/tag)
-(def node/span a/node/span)
 (def node/type? a/node/type?)
 (def node/term? a/node/term?)
 (def node/pat? a/node/pat?)
 (def node/decl? a/node/decl?)
 
-(def parse/type-text pr/parse/type-text)
-(def parse/expr-text pr/parse/expr-text)
+(defn parse/type-text [text &opt prec sx]
+  (let [syn (or sx (x/syntax/default))]
+    (when prec
+      (eachp [op spec] prec
+        (x/syntax/add-operator! syn op (spec :fixity) (spec :level))))
+    (pr/parse/type-text text syn)))
+
+(defn parse/expr-text [text &opt prec sx]
+  (let [syn (or sx (x/syntax/default))]
+    (when prec
+      (eachp [op spec] prec
+        (x/syntax/add-operator! syn op (spec :fixity) (spec :level))))
+    (pr/parse/expr-text text syn)))
+
 (def parse/pat-text pat/parse/pat-text)
+(def parse/fields d/parse/fields)
 (def parse/source d/parse/source)
+(def parse/program d/parse/source)
+
+(def syntax/default x/syntax/default)
+(def syntax/clone x/syntax/clone)
+(def syntax/add-literal! x/syntax/add-literal!)
+(def syntax/add-quant-alias! x/syntax/add-quant-alias!)
+(def syntax/add-operator! x/syntax/add-operator!)
 
 (def lower/type lo/lower/type)
 (def lower/term lo/lower/term)
-(def lower/pat lo/lower/pat)
-(def lower/decl lo/lower/decl)
-(def lower/clause lo/lower/clause)
 (def lower/program lo/lower/program)
 
 (defn parse/type [xv &opt prec sx]
   (if (string? xv)
-    (parse/type-text xv (or prec @{}) (or sx (x/syntax/default)))
+    (let [syn (or sx (x/syntax/default))]
+      (when prec
+        (eachp [op spec] prec
+          (x/syntax/add-operator! syn op (spec :fixity) (spec :level))))
+      (parse/type-text xv nil syn))
     (do
       (when (and (a/ast/debug-checks?) (not (a/node/type? xv)))
         (errorf "parse/type expected type node, got: %v" xv))
@@ -89,7 +62,11 @@
 
 (defn parse/expr [xv &opt prec sx]
   (if (string? xv)
-    (parse/expr-text xv (or prec @{}) (or sx (x/syntax/default)))
+    (let [syn (or sx (x/syntax/default))]
+      (when prec
+        (eachp [op spec] prec
+          (x/syntax/add-operator! syn op (spec :fixity) (spec :level))))
+      (parse/expr-text xv nil syn))
     (do
       (when (and (a/ast/debug-checks?) (not (a/node/term? xv)))
         (errorf "parse/expr expected term node, got: %v" xv))
@@ -103,84 +80,23 @@
         (errorf "parse/pat expected pattern node, got: %v" xv))
       xv)))
 
-(defn parse/program [xv &opt sx]
-  (if (string? xv)
-    (parse/source xv (or sx (x/syntax/default)))
-    (do
-      (when (and (a/ast/debug-checks?) (not= (a/node/tag xv) :program))
-        (errorf "parse/program expected :program node, got: %v" xv))
-      xv)))
-
 (def exports
-  {:ast/debug-checks? a/ast/debug-checks?
-   :ast/set-debug-checks! a/ast/set-debug-checks!
-   :syntax/default x/syntax/default
-   :syntax/clone x/syntax/clone
-   :syntax/add-literal! x/syntax/add-literal!
-   :syntax/add-quant-alias! x/syntax/add-quant-alias!
-   :syntax/add-type-ident-resolver! x/syntax/add-type-ident-resolver!
-   :pos a/pos
-   :span a/span
-   :span/none a/span/none
-
-   :ty/hole a/ty/hole
-   :ty/universe a/ty/universe
-   :ty/name a/ty/name
-   :ty/var a/ty/var
-   :ty/app a/ty/app
-   :ty/arrow a/ty/arrow
-   :ty/binder a/ty/binder
-   :ty/pi a/ty/pi
-   :ty/forall a/ty/forall
-   :ty/sigma a/ty/sigma
-   :ty/exists a/ty/exists
-   :ty/op a/ty/op
-
-   :tm/hole a/tm/hole
-   :tm/var a/tm/var
-   :tm/ref a/tm/ref
-   :tm/nat a/tm/nat
-   :tm/app a/tm/app
-   :tm/lam a/tm/lam
-   :tm/let a/tm/let
-   :tm/op a/tm/op
-
-   :pat/wild a/pat/wild
-   :pat/hole a/pat/hole
-   :pat/var a/pat/var
-   :pat/con a/pat/con
-   :pat/nat a/pat/nat
-
-   :decl/param a/decl/param
-   :decl/field-named a/decl/field-named
-   :decl/field-anon a/decl/field-anon
-   :decl/ctor-plain a/decl/ctor-plain
-   :decl/ctor-indexed a/decl/ctor-indexed
-   :decl/clause a/decl/clause
-   :decl/prec a/decl/prec
-   :decl/data a/decl/data
-   :decl/func a/decl/func
-   :program a/program
-
-   :node/tag a/node/tag
-   :node/span a/node/span
-   :node/type? a/node/type?
-   :node/term? a/node/term?
-   :node/pat? a/node/pat?
-   :node/decl? a/node/decl?
-
-   :parse/type parse/type
-   :parse/expr parse/expr
-   :parse/pat parse/pat
+  {:node/tag node/tag
+   :node/type? node/type?
+   :node/term? node/term?
+   :node/pat? node/pat?
+   :node/decl? node/decl?
+   
    :parse/type-text parse/type-text
    :parse/expr-text parse/expr-text
    :parse/pat-text parse/pat-text
+   :parse/fields parse/fields
    :parse/source parse/source
-   :parse/program parse/program
-
+   
    :lower/type lower/type
    :lower/term lower/term
-   :lower/pat lower/pat
-   :lower/decl lower/decl
-   :lower/clause lower/clause
-   :lower/program lower/program})
+   :lower/program lower/program
+   
+   :parse/type parse/type
+   :parse/expr parse/expr
+   :parse/pat parse/pat})

--- a/src/frontend/surface/pratt.janet
+++ b/src/frontend/surface/pratt.janet
@@ -6,8 +6,8 @@
 
 (defn- trim [s] (string/trim s))
 
-(defn- pstate/new [tokens mode prec sx]
-  @{:tokens tokens :i 0 :mode mode :prec prec :sx sx})
+(defn- pstate/new [tokens mode sx]
+  @{:tokens tokens :i 0 :mode mode :sx sx})
 
 (defn- pstate/peek [st]
   (if (< (st :i) (length (st :tokens)))
@@ -22,11 +22,11 @@
 (defn- pstate/expect [st kind]
   (let [t (pstate/next st)]
     (when (not= (t :k) kind)
-      (errorf "expected token %v, got %v" kind t))
+      (errorf "expected token %v, got %v (k: %v v: %v)" kind t (t :k) (t :v)))
     t))
 
-(defn- prec/spec [prec op]
-  (get prec op))
+(defn- prec/spec [st op]
+  (get ((st :sx) :operators) op))
 
 (defn- op-lbp [level] (+ 10 level))
 
@@ -36,9 +36,12 @@
   (pstate/expect st :lparen)
   (let [nm ((pstate/expect st :ident) :v)]
     (pstate/expect st :colon)
-    (let [dom (parse/expr st 0)]
-      (pstate/expect st :rparen)
-      (a/ty/binder nm dom (a/span/none)))))
+    (let [old-mode (st :mode)]
+      (put st :mode :type)
+      (let [dom (parse/expr st 0)]
+        (put st :mode old-mode)
+        (pstate/expect st :rparen)
+        (a/ty/binder nm dom (a/span/none))))))
 
 (defn- resolve-type-ident [st name]
   (var out nil)
@@ -54,6 +57,7 @@
 (defn- nud/type [st tok]
   (match (tok :k)
     :hole (a/ty/hole (tok :v) (a/span/none))
+    :nat (a/ty/universe (tok :v) (a/span/none))
     :ident (resolve-type-ident st (tok :v))
     :lparen (let [e (parse/expr st 0)]
               (pstate/expect st :rparen)
@@ -66,13 +70,13 @@
             mk (quant-builder st q)]
         (mk binder body (a/span/none))))
     :op
-    (if-let [spec (prec/spec (st :prec) (tok :v))]
+    (if-let [spec (prec/spec st (tok :v))]
       (if (= (spec :fixity) :prefix)
         (let [rhs (parse/expr st (op-lbp (spec :level)))]
           (a/ty/op (tok :v) @[rhs] (a/span/none)))
         (errorf "operator %v is not prefix in type position" (tok :v)))
       (errorf "unknown prefix type operator %v" (tok :v)))
-    _ (errorf "unexpected type token %v" tok)))
+    _ (errorf "unexpected type token %v" (tok :k))))
 
 (defn- nud/term [st tok]
   (match (tok :k)
@@ -84,11 +88,21 @@
               e)
     :lambda
     (let [params @[]]
-      (while (= ((pstate/peek st) :k) :ident)
-        (array/push params ((pstate/next st) :v)))
+      (while true
+        (let [pk (pstate/peek st)]
+          (cond
+            (= (pk :k) :ident)
+            (array/push params ((pstate/next st) :v))
+
+            (= (pk :k) :lparen)
+            (array/push params (parse-binder st))
+
+            true (break))))
       (when (zero? (length params))
         (error "lambda expects at least one parameter"))
-      (pstate/expect st :fat-arrow)
+      (let [sep (pstate/next st)]
+        (when (and (not= (sep :k) :dot) (not= (sep :k) :fat-arrow))
+          (errorf "lambda expects '.' or '=>', got %v" sep)))
       (a/tm/lam params (parse/expr st 0) (a/span/none)))
     :kw/let
     (let [name ((pstate/expect st :ident) :v)]
@@ -97,17 +111,18 @@
         (pstate/expect st :kw/in)
         (a/tm/let name v (parse/expr st 0) (a/span/none))))
     :op
-    (if-let [spec (prec/spec (st :prec) (tok :v))]
+    (if-let [spec (prec/spec st (tok :v))]
       (if (= (spec :fixity) :prefix)
         (let [rhs (parse/expr st (op-lbp (spec :level)))]
           (a/tm/op (tok :v) @[rhs] (a/span/none)))
         (errorf "operator %v is not prefix in term position" (tok :v)))
       (errorf "unknown prefix term operator %v" (tok :v)))
-    _ (errorf "unexpected term token %v" tok)))
+    _ (errorf "unexpected term token %v" (tok :k))))
 
 (defn- can-start-atom? [tok]
   (let [k (tok :k)]
-    (or (= k :hole) (= k :ident) (= k :nat) (= k :lparen))))
+    (or (= k :hole) (= k :ident) (= k :nat) (= k :lparen)
+        (= k :quant) (= k :lambda) (= k :kw/let))))
 
 (set parse/expr
      (fn [st min-bp]
@@ -126,52 +141,47 @@
                             (a/ty/app out rhs (a/span/none))
                             (a/tm/app out rhs (a/span/none)))))
 
-               (and (= nk :arrow) (<= min-bp 20))
-               (do
-                 (pstate/next st)
-                 (let [rhs (parse/expr st 20)]
-                   (set out (if (= (st :mode) :type)
-                              (a/ty/arrow out rhs (a/span/none))
-                              (a/tm/op "->" @[out rhs] (a/span/none))))))
-
-               (and (= nk :op)
-                    (if-let [spec (prec/spec (st :prec) (next :v))]
-                      (or (= (spec :fixity) :infixl)
-                          (= (spec :fixity) :infixr)
-                          (= (spec :fixity) :postfix))
-                      false))
-               (let [spec (prec/spec (st :prec) (next :v))
+               (let [spec (prec/spec st (next :v))
+                     p (if spec (op-lbp (spec :level)) -1)]
+                 (and (= nk :op)
+                      (if spec
+                        (and (> p min-bp)
+                             (or (= (spec :fixity) :infixl)
+                                 (= (spec :fixity) :infixr)
+                                 (= (spec :fixity) :postfix)))
+                        false)))
+               (let [op-tok (pstate/next st)
+                     spec (prec/spec st (op-tok :v))
                      p (op-lbp (spec :level))]
-                 (if (<= p min-bp)
-                   (break)
-                   (do
-                     (pstate/next st)
-                     (if (= (spec :fixity) :postfix)
-                       (set out (if (= (st :mode) :type)
-                                  (a/ty/op (next :v) @[out] (a/span/none))
-                                  (a/tm/op (next :v) @[out] (a/span/none))))
-                       (let [rbp (if (= (spec :fixity) :infixl) (+ p 1) p)
-                             rhs (parse/expr st rbp)]
-                         (set out (if (= (st :mode) :type)
-                                    (a/ty/op (next :v) @[out rhs] (a/span/none))
-                                    (a/tm/op (next :v) @[out rhs] (a/span/none)))))))))
+                 (if (= (spec :fixity) :postfix)
+                   (set out (if (= (st :mode) :type)
+                              (a/ty/op (op-tok :v) @[out] (a/span/none))
+                              (a/tm/op (op-tok :v) @[out] (a/span/none))))
+                   (let [rbp (if (= (spec :fixity) :infixr) (dec p) p)
+                         rhs (parse/expr st rbp)]
+                     (set out (if (= (st :mode) :type)
+                                (if (or (= (op-tok :v) "->") (= (op-tok :v) "→"))
+                                  (a/ty/arrow out rhs (a/span/none))
+                                  (a/ty/op (op-tok :v) @[out rhs] (a/span/none)))
+                                (a/tm/op (op-tok :v) @[out rhs] (a/span/none)))))))
 
                true
                (break))))
          out)))
 
-(defn- parse-with-pratt [text mode prec sx]
-  (let [st (pstate/new (lx/lex text sx) mode prec sx)
+(defn- parse-with-pratt [text mode sx]
+  (let [st (pstate/new (lx/lex text sx) mode sx)
         out (parse/expr st 0)]
-    (when (not= ((pstate/peek st) :k) :eof)
-      (errorf "unexpected trailing token: %v" (pstate/peek st)))
+    (let [trail (pstate/peek st)]
+      (when (not= (trail :k) :eof)
+        (errorf "unexpected trailing token: %v (%v)" (trail :k) (trail :v))))
     out))
 
-(defn parse/type-text [text &opt prec sx]
-  (parse-with-pratt (trim text) :type (or prec @{}) (or sx (x/syntax/default))))
+(defn parse/type-text [text &opt sx]
+  (parse-with-pratt (trim text) :type (or sx (x/syntax/default))))
 
-(defn parse/expr-text [text &opt prec sx]
-  (parse-with-pratt (trim text) :term (or prec @{}) (or sx (x/syntax/default))))
+(defn parse/expr-text [text &opt sx]
+  (parse-with-pratt (trim text) :term (or sx (x/syntax/default))))
 
 (def exports
   {:parse/type-text parse/type-text

--- a/src/frontend/surface/syntax.janet
+++ b/src/frontend/surface/syntax.janet
@@ -30,14 +30,16 @@
 
 (defn syntax/default []
   @{:literals @[
-      {:lit "->" :k :arrow :v :arrow}
-      {:lit "→" :k :arrow :v :arrow}
+      {:lit "->" :k :op :v "->"}
+      {:lit "→" :k :op :v "->"}
       {:lit "=>" :k :fat-arrow :v :fat-arrow}
       {:lit "\\" :k :lambda :v :lambda}
       {:lit "λ" :k :lambda :v :lambda}
+      {:lit "Pi" :k :quant :v :pi}
       {:lit "Π" :k :quant :v :pi}
-      {:lit "∀" :k :quant :v :pi}
       {:lit "forall" :k :quant :v :pi}
+      {:lit "∀" :k :quant :v :pi}
+      {:lit "Sigma" :k :quant :v :sigma}
       {:lit "Σ" :k :quant :v :sigma}
       {:lit "∃" :k :quant :v :sigma}
     ]
@@ -56,19 +58,49 @@
           nil))
       (fn [name sp]
         (a/ty/var name sp))
-    ]})
+    ]
+    :operators @{"->" {:fixity :infixr :level 20}}})
 
 (defn syntax/clone [sx]
   @{:literals (array/slice (sx :literals))
     :type/quant-builders (table/clone (sx :type/quant-builders))
-    :type/ident-resolvers (array/slice (sx :type/ident-resolvers))})
+    :type/ident-resolvers (array/slice (sx :type/ident-resolvers))
+    :operators (table/clone (sx :operators))})
 
-(defn syntax/add-literal! [sx lit kind value]
-  (array/push (sx :literals) {:lit lit :k kind :v value})
+(defn syntax/add-literal! [sx lit kind val]
+  (array/push (sx :literals) {:lit lit :k kind :v val})
   sx)
 
-(defn syntax/add-quant-alias! [sx alias quant-kind]
-  (syntax/add-literal! sx alias :quant quant-kind)
+(defn syntax/add-operator! [sx op fixity level]
+  (put (sx :operators) op {:fixity fixity :level level})
+  # Ensure the operator is also in literals so the lexer can see it
+  (var found-lit false)
+  (each entry (sx :literals)
+    (when (= (entry :lit) op)
+      (set found-lit true)
+      (break)))
+  (when (not found-lit)
+    (syntax/add-literal! sx op :op op))
+  sx)
+
+(defn syntax/add-alias! [sx new-lit target-lit]
+  (var found nil)
+  (each entry (sx :literals)
+    (when (= (entry :lit) target-lit)
+      (set found entry)
+      (break)))
+  (if found
+    (syntax/add-literal! sx new-lit (found :k) (found :v))
+    # If not a literal, maybe it's a known quantifier keyword?
+    (match target-lit
+      "forall" (syntax/add-literal! sx new-lit :quant :pi)
+      "sigma" (syntax/add-literal! sx new-lit :quant :sigma)
+      "pi" (syntax/add-literal! sx new-lit :quant :pi)
+      (errorf "cannot alias unknown literal or keyword: %v" target-lit)))
+  sx)
+
+(defn syntax/add-quant-alias! [sx new-lit kind]
+  (syntax/add-literal! sx new-lit :quant kind)
   sx)
 
 (defn syntax/add-type-ident-resolver! [sx resolver]
@@ -106,6 +138,8 @@
    :syntax/default syntax/default
    :syntax/clone syntax/clone
    :syntax/add-literal! syntax/add-literal!
+   :syntax/add-alias! syntax/add-alias!
    :syntax/add-quant-alias! syntax/add-quant-alias!
    :syntax/add-type-ident-resolver! syntax/add-type-ident-resolver!
-   :syntax/match-literal syntax/match-literal})
+   :syntax/match-literal syntax/match-literal
+   :syntax/add-operator! syntax/add-operator!})


### PR DESCRIPTION
## Summary
- extend the surface parser/lowerer to support branchwise indexed-family constructors (including Aya-style index-echo constructor sugar) and improve operator/alias handling in the Pratt pipeline
- elaborate constructor parameter binder types into core terms and add constructor-aware checking in the CLI runner so top-level `check` works for indexed constructors like `fzero`/`fsuc`
- keep goal collection behavior for CLI interactions while preserving strict error behavior in the core typechecker tests

## Validation
- `jpm test`
- `janet requiem.janet fin_test.requiem`