### PR TITLE
Improve surface syntax and goal reporting

### DIFF
--- a/Prelude.requiem
+++ b/Prelude.requiem
@@ -1,0 +1,18 @@
+# Prelude.requiem
+# Standard Library for Requiem Surface Syntax
+
+# Quantifier Aliases
+alias U = Type
+alias forall = Pi
+alias ∀ = Pi
+alias Π = Pi
+alias sigma = Sigma
+alias Σ = Sigma
+alias ∃ = Sigma
+
+# Arrow Aliases
+infixr 20 ->
+alias → = ->
+
+# Lambda Aliases
+alias λ = \

--- a/examples/selector-style-showcase.requiem
+++ b/examples/selector-style-showcase.requiem
@@ -10,6 +10,7 @@ Unit:
   tt
 
 Void:
+  ()
 
 List(A: Type):
   nil

--- a/requiem
+++ b/requiem
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec janet "/home/user/Repos/Requiem/requiem.janet" "$@"

--- a/requiem.janet
+++ b/requiem.janet
@@ -5,6 +5,8 @@
 (import ./src/frontend/surface/parser :as sp)
 (import ./src/elab :as e)
 (import ./src/coreTT :as tt)
+(import /build/hamt :as h)
+(import ./src/levels :as lvl)
 (import ./src/pretty :as pp)
 (import ./src/matches :as mt)
 
@@ -14,7 +16,18 @@
     [:var x] (string x)
     [:type l] (string "Type" l)
     [:hole name] (if name (string "?" name) "?")
-    [:list xs] (string "(" (string/join (map print/node xs) " ") ")")
+    [:list xs]
+    (if (and (= (length xs) 3)
+             (tuple? (xs 0))
+             (= ((xs 0) 0) :atom)
+             (= ((xs 0) 1) "fn"))
+      (let [binder (xs 1)
+            binder-text (match binder
+                          [:atom name] name
+                          [:list bs] (string/join (map print/node bs) " ")
+                          _ (print/node binder))]
+        (string "λ" binder-text "." (print/node (xs 2))))
+      (string "(" (string/join (map print/node xs) " ") ")"))
     [:app f a] (string "(" (print/node f) " " (print/node a) ")")
     [:t-pi A _] (string "Pi(" (print/node A) ", ...)")
     [:t-sigma A _] (string "Sigma(" (print/node A) ", ...)")
@@ -30,7 +43,7 @@
   (match param
     [:param name ty _]
     (if ty
-      (string name " : " (print/node ty))
+      (string name ": " (print/node ty))
       name)
     _ (string/format "%v" param)))
 
@@ -73,50 +86,69 @@
   (match binder
     [:bind name ty]
     (string name
-            " : "
-              (if (and (tuple? ty)
-                     (or (= (ty 0) :atom)
-                         (= (ty 0) :list)))
+            ": "
+               (if (and (tuple? ty)
+                      (or (= (ty 0) :atom)
+                          (= (ty 0) :list)))
               (print/node ty)
               (pp/print/tm ty)))
     _
     (string/format "%v" binder)))
 
-(defn decl/summary [decl]
+(defn- print/lowered-ctor [ctor]
+  (match ctor
+    [:ctor name pat-binders patterns ctor-params _ _]
+    (let [indices (if (zero? (length patterns))
+                    nil
+                    (string/join (map print/node (map mt/pat/to-term patterns)) ", "))
+          params (tuple/join pat-binders ctor-params)
+          render-param (fn [b]
+                         (match b
+                           [:bind bname bty]
+                           (if (string/has-prefix? "_arg" bname)
+                             (print/node bty)
+                             (print/binder b))
+                           _ (string/format "%v" b)))
+          suffix (if (zero? (length params))
+                   ""
+                   (string "(" (string/join (map render-param params) ", ") ")"))]
+      (if indices
+        (string indices " = " name suffix)
+        (string name suffix)))
+
+    _
+    (string/format "%v" ctor)))
+
+(defn- print/header [name params result printer]
+  (string name
+          (if (zero? (length params))
+            ""
+            (string "(" (string/join (map print/binder params) ", ") ")"))
+          ": "
+          (printer result)))
+
+(defn decl/render [decl]
   (let [tag (decl 0)]
     (cond
       (= tag :decl/data)
-      (let [name (decl 1)
-            a2 (decl 2)
-            a3 (decl 3)
-            a4 (decl 4)]
-        (if (array? a3)
-          (string "data "
-                  name
-                  (if (zero? (length a2))
-                    ""
-                    (string "(" (string/join (map print/param a2) ", ") ")"))
-                  " ("
-                  (length a3)
-                  " ctor(s): "
-                  (string/join (map print/ctor a3) "; ")
-                  ")")
-          (string "data "
-                  name
-                  (if (zero? (length a2))
-                    ""
-                    (string "(" (string/join (map print/binder a2) ", ") ")"))
-                  " : "
-                  (print/node a3)
-                  " ("
-                  (length a4)
-                  " ctor(s))")))
+      (string (decl 1)
+              (if (zero? (length (decl 2)))
+                ""
+                (string "(" (string/join (map print/binder (decl 2)) ", ") ")"))
+              ": "
+              (print/node (decl 3))
+              (if (zero? (length (decl 4)))
+                ""
+                (string "\n  " (string/join (map print/lowered-ctor (decl 4)) "\n  "))))
 
       (= tag :decl/func)
-      (string "def " (decl 1) " : " (print/node (decl 2)) " (" (length (decl 3)) " clause(s))")
+      (string (print/header (decl 1) (decl 2) (decl 3) print/node)
+              "\n  "
+              (length (decl 4))
+              " clause(s)")
 
       (= tag :decl/record)
-      (string "record " (decl 1) " (" (length (decl 2)) " entry(ies))")
+      (string (decl 1) "\n  " (length (decl 2)) " entry(ies)")
 
       (= tag :decl/compute)
       (string "compute " (print/node (decl 1)))
@@ -125,26 +157,19 @@
       (string "check " (print/node (decl 1)) " : " (print/node (decl 2)))
 
       (= tag :core/data)
-      (string "data "
-              (decl 1)
+      (string (decl 1)
               (if (zero? (length (decl 2)))
                 ""
                 (string "(" (string/join (map print/binder (decl 2)) ", ") ")"))
-              " (core, "
+              "\n  "
               (length (decl 4))
-              " ctor(s))")
+              " ctor(s)")
 
       (= tag :core/func)
-      (string "def "
-              (decl 1)
-              (if (zero? (length (decl 2)))
-                ""
-              (string "(" (string/join (map print/binder (decl 2)) ", ") ")"))
-              " : "
-              (pp/print/tm (decl 3))
-              " (core, "
+      (string (print/header (decl 1) (decl 2) (decl 3) pp/print/tm)
+              "\n  "
               (length (decl 5))
-              " clause(s))")
+              " clause(s)")
 
       (= tag :core/compute)
       (string "compute " (pp/print/tm (decl 1)))
@@ -155,8 +180,354 @@
       true
       (string "unknown declaration: " (string/format "%v" decl)))))
 
+(defn- print/decls [decls]
+  (eachp [i decl] decls
+    (print (decl/render decl))
+    (when (< (+ i 1) (length decls))
+      (print ""))))
+
+(var goal-print/names nil)
+(var goal-print/next-id 0)
+
+(defn- goal-print/base-name [n]
+  (let [names @["x" "y" "z" "w" "u" "v" "a" "b" "c" "d"]
+        k (% n (length names))
+        q (div n (length names))
+        base (names k)]
+    (if (= q 0) base (string base q))))
+
+(defn- goal-print/fresh! []
+  (let [name (goal-print/base-name goal-print/next-id)]
+    (++ goal-print/next-id)
+    name))
+
+(var print/goal-ne nil)
+(var print/goal-nf nil)
+(var print/goal-sem nil)
+
+(set print/goal-ne
+     (fn [ne]
+       (cond
+         (and (tuple? ne) (= (ne 0) :nvar)) (or (get goal-print/names (ne 1)) (string (ne 1)))
+         (and (tuple? ne) (= (ne 0) :napp)) (string "(" (print/goal-ne (ne 1)) " " (print/goal-nf (ne 2)) ")")
+         (and (tuple? ne) (= (ne 0) :nfst)) (string "fst " (print/goal-ne (ne 1)))
+         (and (tuple? ne) (= (ne 0) :nsnd)) (string "snd " (print/goal-ne (ne 1)))
+         (and (tuple? ne) (= (ne 0) :nJ)) "J ..."
+         true (string/format "%v" ne))))
+
+(set print/goal-nf
+     (fn [nf]
+       (let [tag (if (tuple? nf) (nf 0) nil)]
+         (cond
+         (= tag tt/NF/Type) (string "Type" (nf 1))
+         (= tag tt/NF/Pi)
+         (let [actual (gensym)
+               shown (goal-print/fresh!)]
+           (put goal-print/names actual shown)
+           (string "Pi(" shown ": " (print/goal-nf (nf 1)) "). " (print/goal-nf ((nf 2) actual))))
+         (= tag tt/NF/Sigma)
+         (let [actual (gensym)
+               shown (goal-print/fresh!)]
+           (put goal-print/names actual shown)
+           (string "Sigma(" shown ": " (print/goal-nf (nf 1)) "). " (print/goal-nf ((nf 2) actual))))
+         (= tag tt/NF/Id)
+         (string "Id " (print/goal-nf (nf 1)) " " (print/goal-nf (nf 2)) " " (print/goal-nf (nf 3)))
+         (= tag tt/NF/Refl) (string "refl " (print/goal-nf (nf 1)))
+         (= tag tt/NF/Pair) (string "(" (print/goal-nf (nf 1)) ", " (print/goal-nf (nf 2)) ")")
+         (= tag tt/NF/Neut) (print/goal-ne (nf 1))
+         true (string/format "%v" nf)))))
+
+(set print/goal-sem
+     (fn [sem]
+       (let [tag (if (tuple? sem) (sem 0) nil)]
+         (cond
+         (= tag tt/T/Type)
+         (string "Type"
+                 (let [l (sem 1)]
+                   (if (or (int? l) (lvl/const? l) (lvl/shift? l))
+                     (lvl/value l)
+                     (string/format "%v" l))))
+         (= tag tt/T/Neutral) (print/goal-ne (sem 1))
+         (= tag tt/T/Pi)
+         (let [actual (gensym)
+               shown (goal-print/fresh!)]
+           (put goal-print/names actual shown)
+           (let [A (sem 1)
+                 B (sem 2)
+                 arg (tt/raise A (tt/ne/var actual))]
+             (string "Pi(" shown ": " (print/goal-sem A) "). " (print/goal-sem (B arg)))))
+         (= tag tt/T/Sigma)
+         (let [actual (gensym)
+               shown (goal-print/fresh!)]
+           (put goal-print/names actual shown)
+           (let [A (sem 1)
+                 B (sem 2)
+                 arg (tt/raise A (tt/ne/var actual))]
+             (string "Sigma(" shown ": " (print/goal-sem A) "). " (print/goal-sem (B arg)))))
+         (= tag tt/T/Id)
+         (let [A (sem 1)
+               x (sem 2)
+               y (sem 3)]
+           (string "Id " (print/goal-sem A) " "
+                   (print/goal-nf (tt/lower A x)) " "
+                   (print/goal-nf (tt/lower A y))))
+         (= tag tt/T/Pair) (string "(" (print/goal-sem (sem 1)) ", " (print/goal-sem (sem 2)) ")")
+         (= tag tt/T/Refl) (string "refl " (string/format "%v" (sem 1)))
+         true (string/format "%v" sem)))))
+
+(defn- print/goal-type [sem names]
+  (let [saved-names goal-print/names
+        saved-next goal-print/next-id
+        start-next (reduce (fn [n _] (+ n 1)) 0 names)]
+    (set goal-print/names (table/clone names))
+    (set goal-print/next-id start-next)
+    (def out (print/goal-sem sem))
+    (set goal-print/names saved-names)
+    (set goal-print/next-id saved-next)
+    out))
+
+(defn- filter/goal-ctx [ctx hidden-names]
+  (reduce (fn [acc entry]
+            (if (get hidden-names (entry 0))
+              acc
+              [;acc entry]))
+          @[]
+          ctx))
+
+(defn- only/goal-ctx [ctx hidden-names]
+  (reduce (fn [acc entry]
+            (if (get hidden-names (entry 0))
+              [;acc entry]
+              acc))
+          @[]
+          ctx))
+
+(defn- goal/local-name-map [local-ctx]
+  (let [out @{}]
+    (eachp [i entry] local-ctx
+      (put out (entry 0) (goal-print/base-name i)))
+    out))
+
+(defn- bind-spec/name [node]
+  (match node
+    [:atom name] name
+    [:list xs]
+    (cond
+      (and (= (length xs) 2)
+           (= ((xs 0) 0) :atom)
+           (string/has-suffix? ":" ((xs 0) 1)))
+      (string/slice ((xs 0) 1) 0 (- (length ((xs 0) 1)) 1))
+
+      (and (= (length xs) 3)
+           (= ((xs 0) 0) :atom)
+           (= ((xs 0) 1) ":")
+           (= ((xs 1) 0) :atom))
+      ((xs 1) 1)
+
+      true nil)
+
+    _ nil))
+
+(defn- term/lambda-names [tm]
+  (match tm
+    [:list xs]
+    (if (and (= (length xs) 3)
+             (= ((xs 0) 0) :atom)
+             (= ((xs 0) 1) "fn"))
+      (let [binder (xs 1)
+            body (xs 2)
+            names (match binder
+                    [:atom name] @[name]
+                    [:list bs] (reduce (fn [acc b]
+                                         (if-let [name (bind-spec/name b)]
+                                           [;acc name]
+                                           acc))
+                                       @[]
+                                       bs)
+                    _ @[])]
+        (tuple/join names (term/lambda-names body)))
+      @[])
+
+    _ @[]))
+
+(defn- print/bindings [entries indent names]
+  (if (zero? (length entries))
+    (printf "%s<empty>" indent)
+    (each c entries
+      (printf "%s%s : %s"
+              indent
+              (or (get names (c 0)) (string (c 0)))
+              (print/goal-type (c 1) names)))))
+
+(defn- print/goal-block [g hidden-names preferred-names &opt indent]
+  (let [indent (or indent "  ")
+        local-ctx (filter/goal-ctx (g :ctx) hidden-names)
+        global-ctx (only/goal-ctx (g :ctx) hidden-names)
+        local-names (let [out @{}]
+                      (eachp [i entry] local-ctx
+                        (put out
+                             (entry 0)
+                             (if (< i (length preferred-names))
+                               (preferred-names i)
+                               (goal-print/base-name i))))
+                      out)]
+    (printf "%sLocal context:" indent)
+    (print/bindings local-ctx (string indent "  ") local-names)
+    (printf "%sAvailable names:" indent)
+    (print/bindings global-ctx (string indent "  ") local-names)
+    (printf "%s------------------------------" indent)
+    (printf "%s?%s : %s" indent (string (g :name)) (print/goal-type (g :expected) local-names))))
+
+(defn- print/goals [goals hidden-names preferred-name-groups &opt header indent]
+  (let [indent (or indent "  ")]
+    (when (> (length goals) 0)
+      (when header
+        (print header))
+      (eachp [i g] goals
+        (print/goal-block g
+                          hidden-names
+                          (if (< i (length preferred-name-groups))
+                            (preferred-name-groups i)
+                            @[])
+                          indent)
+        (when (< (+ i 1) (length goals))
+          (print ""))))))
+
+(defn- global-names [Γ]
+  (reduce (fn [acc k]
+            (do (put acc k true) acc))
+          @{}
+          (h/keys Γ)))
+
 (defn- surface-file? [path]
   (string/has-suffix? ".requiem" path))
+
+(defn- resolve-path [path]
+  (let [resolved (if (string/has-prefix? "@examples/" path)
+                   (string "examples/" (string/slice path (length "@examples/")))
+                   path)]
+    (if (os/stat resolved)
+      resolved
+      (if (and (not (string/has-suffix? ".requiem" resolved))
+               (os/stat (string resolved ".requiem")))
+        (string resolved ".requiem")
+        resolved))))
+
+(defn- mode/runs-computes? [mode]
+  (or (= mode :run) (= mode :compile)))
+
+(defn- with-default-prelude [src]
+  (string "import \"Prelude\"\n\n" src))
+
+(defn- print/help []
+  (print "Usage: requiem [mode] <file.requiem>")
+  (print "")
+  (print "Modes:")
+  (print "  run      parse, elaborate, and execute compute blocks")
+  (print "  check    parse and elaborate without running compute blocks")
+  (print "  compile  alias of run")
+  (print "  help     show this help")
+  (print "")
+  (print "Examples:")
+  (print "  requiem examples/test.requiem")
+  (print "  requiem check examples/test.requiem")
+  (print "  requiem compile @examples/test.requiem"))
+
+(defn- print/surface-type [ty]
+  (match ty
+    [:ty/hole _ _] (print/node (sp/lower/type ty))
+    [:ty/universe _ _] (print/node (sp/lower/type ty))
+    [:ty/name _ _] (print/node (sp/lower/type ty))
+    [:ty/var _ _] (print/node (sp/lower/type ty))
+    [:ty/app _ _ _] (print/node (sp/lower/type ty))
+    [:ty/arrow _ _ _] (print/node (sp/lower/type ty))
+    [:ty/pi _ _ _] (print/node (sp/lower/type ty))
+    [:ty/sigma _ _ _] (print/node (sp/lower/type ty))
+    [:ty/op _ _ _] (print/node (sp/lower/type ty))
+    _ (print/node ty)))
+
+(defn- collect/type-holes [ty ctx out]
+  (match ty
+    [:ty/hole name _]
+    (array/push out {:name (or name "_") :expected "Type?" :ctx ctx})
+
+    [:ty/pi binder body _]
+    (do
+      (collect/type-holes (binder 2) ctx out)
+      (collect/type-holes body [;ctx [(binder 1) (binder 2)]] out))
+
+    [:ty/sigma binder body _]
+    (do
+      (collect/type-holes (binder 2) ctx out)
+      (collect/type-holes body [;ctx [(binder 1) (binder 2)]] out))
+
+    [:ty/arrow dom cod _]
+    (do
+      (collect/type-holes dom ctx out)
+      (collect/type-holes cod ctx out))
+
+    [:ty/app f a _]
+    (do
+      (collect/type-holes f ctx out)
+      (collect/type-holes a ctx out))
+
+    [:ty/op _ args _]
+    (each arg args (collect/type-holes arg ctx out))
+
+    _ nil))
+
+(defn- collect/decl-type-holes [decl out]
+  (match decl
+    [:decl/data _ params sort ctors _]
+    (let [ctx @[]]
+      (each p params
+        (when (p 2)
+          (collect/type-holes (p 2) ctx out))
+        (array/push ctx [(p 1) (or (p 2) [:ty/hole nil nil])]))
+      (collect/type-holes sort ctx out)
+      (each ctor ctors
+        (match ctor
+          [:ctor/plain _ fields _]
+          (each f fields
+            (match f
+              [:field/named _ ty _] (collect/type-holes ty ctx out)
+              [:field/anon ty _] (collect/type-holes ty ctx out)
+              _ nil))
+          [:ctor/indexed _ _ fields _]
+          (each f fields
+            (match f
+              [:field/named _ ty _] (collect/type-holes ty ctx out)
+              [:field/anon ty _] (collect/type-holes ty ctx out)
+              _ nil))
+          _ nil)))
+
+    [:decl/func _ ty _ _]
+    (collect/type-holes ty @[] out)
+
+    [:decl/check _ ty _]
+    (collect/type-holes ty @[] out)
+
+    _ nil))
+
+(defn- print/type-hole-goals [goals hidden-names]
+  (when (> (length goals) 0)
+    (print "Type holes:")
+    (each g goals
+      (let [ctx (filter/goal-ctx (g :ctx) hidden-names)
+            globals (only/goal-ctx (g :ctx) hidden-names)]
+        (print "  Local context:")
+        (if (zero? (length ctx))
+          (print "    <empty>")
+          (each c ctx
+            (printf "    %s : %s" (c 0) (print/surface-type (c 1)))))
+        (print "  Available names:")
+        (if (zero? (length globals))
+          (print "    <empty>")
+          (each c globals
+            (printf "    %s : %s" (c 0) (print/goal-type (c 1) @{}))))
+        (print "  ------------------------------")
+        (printf "  ?%s : %s" (g :name) (g :expected))
+        (print "")))))
 
 (defn- binders->ctx [params Γ]
   (reduce (fn [acc b]
@@ -246,6 +617,60 @@
 
     _ tm))
 
+(defn- pattern/extend-ctx [Γ pat expected-core ctor-env]
+  (match pat
+    [:pat/var x]
+    (if (= x "_")
+      Γ
+      (tt/ctx/add Γ x (tt/eval Γ expected-core)))
+
+    [:pat/con head args]
+    (let [info (get (ctor-env :ctors) head)]
+      (if (nil? info)
+        Γ
+        (let [[exp-head exp-args] (term/spine expected-core)]
+          (if (or (nil? exp-head) (not= exp-head (info :data)))
+            Γ
+            (let [ctor (info :ctor)
+                  patterns (ctor 3)
+                  result (if (zero? (length patterns))
+                           (mt/outcome/yes (mt/subst/empty))
+                           (mt/matches* exp-args patterns (ctor-env :ctor-name-set) (mt/subst/empty)))]
+              (if (not (mt/outcome/yes? result))
+                Γ
+                (let [sigma (mt/outcome/subst result)
+                      params (ctor 4)]
+                  (when (not= (length args) (length params))
+                    (errorf "constructor %s expects %d argument(s), got %d"
+                            head
+                            (length params)
+                            (length args)))
+                  (var cur-ctx Γ)
+                  (for i 0 (length params)
+                    (set cur-ctx
+                         (pattern/extend-ctx cur-ctx
+                                             (args i)
+                                             (term/subst ((params i) 2) sigma)
+                                             ctor-env)))
+                  cur-ctx)))))))
+
+    _ Γ))
+
+(defn- clause/extend-ctx [Γ params clause ctor-env]
+  (match clause
+    [:core/clause patterns _]
+    (reduce (fn [cur-ctx i]
+              (if (< i (length params))
+                (pattern/extend-ctx cur-ctx
+                                    (patterns i)
+                                    ((params i) 2)
+                                    ctor-env)
+                cur-ctx))
+            Γ
+            (range (length patterns)))
+
+    _ Γ))
+
 (defn- build-ctor-env [core-decls]
   (let [ctors @{}
         ctor-name-set @{}]
@@ -293,80 +718,125 @@
                 true)
               (tt/check Γ tm expected-sem))))))))
 
-(defn run/file-surface [path]
+(defn run/file-surface [path mode]
   (def start (os/clock))
-  (def src (string (slurp path)))
-  (print "Parsing (surface) " path "...")
+  (def src (with-default-prelude (string (slurp path))))
+  (print "Parsing " path "...")
   (def prog (sp/parse/program src))
+  (def surface-type-holes @[])
+  (each decl (prog 1)
+    (collect/decl-type-holes decl surface-type-holes))
   (def lowered (sp/lower/program prog))
-  (print "Lowered declarations: " (length lowered))
-  (each decl lowered
-    (print "  - " (decl/summary decl)))
+  (def lowered-check-names
+    (reduce (fn [acc decl]
+              (match decl
+                [:decl/check tm _]
+                [;acc (term/lambda-names tm)]
+                _ acc))
+            @[]
+            lowered))
+  (print/decls lowered)
   (def core (e/elab/program lowered))
-  (print "Elaborated core declarations: " (length core))
   (def global-ctx (build-global-ctx core))
+  (def global-name-set (global-names global-ctx))
+  (print/type-hole-goals surface-type-holes global-name-set)
   (def ctor-env (build-ctor-env core))
+  (var check-goal-index 0)
+  (def goal-name-hints @[])
   (array/clear tt/goals) # Reset goals
   (tt/goals/set-collect! true)
   (each decl core
     (match decl
       [:core/func name params result ty clauses]
-      (do
-        (let [Γ (binders->ctx params global-ctx)
-              expected result]
-          (each c clauses
-            (check/with-ctors Γ (c 2) expected ctor-env))))
+      nil
 
       [:core/compute tm]
-      (do
+      (when (mode/runs-computes? mode)
         (printf "\nCompute: %s" (pp/print/tm tm))
         (let [res (tt/nf (tt/ty/type 100) tm)]
           (printf "  => %s" (pp/print/nf res))))
+
       [:core/check tm ty]
       (do
+        (def preferred-names (if (< check-goal-index (length lowered-check-names))
+                               (lowered-check-names check-goal-index)
+                               @[]))
+        (++ check-goal-index)
+        (def goal-count-before (length tt/goals))
         (printf "\nCheck: %s : %s" (pp/print/tm tm) (pp/print/tm ty))
         (check/with-ctors global-ctx tm ty ctor-env)
-        (print "  => OK"))
-      _ nil))
+        (print "  => OK")
+        (let [goal-count-after (length tt/goals)]
+          (when (> goal-count-after goal-count-before)
+            (for _ goal-count-before goal-count-after
+              (array/push goal-name-hints preferred-names))
+            (print "  Current goal:")
+            (print/goals (slice tt/goals goal-count-before goal-count-after)
+                         global-name-set
+                         (slice goal-name-hints goal-count-before goal-count-after)
+                         nil
+                         "    "))))
+       _ nil))
   (tt/goals/set-collect! false)
   
   (let [pending tt/goals]
-    (when (> (length pending) 0)
-      (print "\nPending Goals:")
-      (each g pending
-        (printf "  ?%v : %s" (g :name) (pp/print/nf (g :expected)))
-        (each c (g :ctx)
-          (printf "    %v : %s" (c 0) (pp/print/nf (c 1)))))))
+    (print/goals pending global-name-set goal-name-hints "\nUnsolved goals:" "  "))
 
   (print "")
   (def elapsed (- (os/clock) start))
   (printf "Done. %d declaration(s) in %.3fs" (length lowered) elapsed))
 
-(defn run/file-sexpr [path]
+(defn run/file-sexpr [path mode]
   (def start (os/clock))
   (def src (slurp path))
-  (print "Parsing (sexpr) " path "...")
+  (print "Parsing " path "...")
   (def forms (p/parse/text src))
   (def interactions (length forms))
-  (print "Parsed " interactions " interaction(s)")
   (def lowered (l/lower/program forms))
-  (print "Lowered declarations: " (length lowered))
-  (each decl lowered
-    (print "  - " (decl/summary decl)))
+  (print/decls lowered)
   (def core (e/elab/program lowered))
-  (print "Elaborated core declarations: " (length core))
   (def elapsed (- (os/clock) start))
   (printf "Done. %d interaction(s) in %.3fs" interactions elapsed))
 
-(defn run/file [path]
-  (if (surface-file? path)
-    (run/file-surface path)
-    (run/file-sexpr path)))
+(defn run/file [path mode]
+  (let [resolved (resolve-path path)]
+    (if (surface-file? resolved)
+      (run/file-surface resolved mode)
+      (run/file-sexpr resolved mode))))
+
+(defn- parse/cli [args]
+  (let [args (if (and (> (length args) 0)
+                      (or (string/has-suffix? ".janet" (args 0))
+                          (= (args 0) "requiem")))
+               (slice args 1)
+               args)
+        n (length args)]
+    (cond
+      (= n 1)
+      (match (args 0)
+        "help" [:help nil]
+        "-h" [:help nil]
+        "--help" [:help nil]
+        _ [:run (args 0)])
+
+      (= n 2)
+      (match (args 0)
+        "run" [:run (args 1)]
+        "check" [:check (args 1)]
+        "compile" [:compile (args 1)]
+        "help" [:help nil]
+        _ nil)
+
+      true
+      nil)))
 
 (defn main [& args]
-  (def n (length args))
-  (if (zero? n)
-    (do
-      (print "Usage: requiem <file.requiem>")
-      (os/exit 1))
-    (run/file (args (- n 1)))))
+  (if (zero? (length args))
+    (print/help)
+    (if-let [[mode path] (parse/cli args)]
+      (if (= mode :help)
+        (print/help)
+        (run/file path mode))
+      (do
+        (print/help)
+        (os/exit 1)))))

--- a/src/checker.janet
+++ b/src/checker.janet
@@ -4,6 +4,8 @@
   (let [T/Type (deps :T/Type)
         T/Pi (deps :T/Pi)
         T/Sigma (deps :T/Sigma)
+        T/Pair (deps :T/Pair)
+        T/Neutral (deps :T/Neutral)
         ty/type (deps :ty/type)
         ty/id (deps :ty/id)
         lvl/<= (deps :lvl/<=)
@@ -12,11 +14,10 @@
         sem-eq (deps :sem-eq)
         eval (deps :eval)
         raise (deps :raise)
-        lower (deps :lower)
-        ctx/empty (deps :ctx/empty)
         ctx/add (deps :ctx/add)
         ctx/lookup (deps :ctx/lookup)
         ne/var (deps :ne/var)
+        ne/fst (deps :ne/fst)
         print/sem (deps :print/sem)
         print/tm (deps :print/tm)
         meta (deps :meta)]
@@ -37,14 +38,24 @@
                  arg-sem (raise A1 (ne/var fresh))]
              (subtype (B1 arg-sem) (B2 arg-sem)))))
 
+    (defn tag-of [x]
+      (if (tuple? x) (get x 0) 0))
+
+    (defn fst-sem [p-sem]
+      (let [tag (tag-of p-sem)]
+        (cond
+          (= tag T/Pair) (get p-sem 1)
+          (= tag T/Neutral) [T/Neutral (ne/fst (get p-sem 1))]
+          true (errorf "fst expected pair semantics, got: %s" (print/sem p-sem)))))
+
     (set subtype
          (fn [A B]
-           "Semantic subtyping with cumulative universes and Pi/Sigma variance."
-           (let [tagA (if (tuple? A) (get A 0) 0)
-                 tagB (if (tuple? B) (get B 0) 0)]
-             (cond
-               (and (= tagA T/Type) (= tagB T/Type))
-               (lvl/<= (get A 1) (get B 1))
+            "Semantic subtyping with cumulative universes and Pi/Sigma variance."
+            (let [tagA (tag-of A)
+                  tagB (tag-of B)]
+              (cond
+                (and (= tagA T/Type) (= tagB T/Type))
+                (lvl/<= (get A 1) (get B 1))
 
                (and (= tagA T/Pi) (= tagB T/Pi))
                (let [[_ A1 B1] A
@@ -62,11 +73,19 @@
     (defn check-univ [Γ A]
       "Check that A is a universe and return its level"
       (let [UA (infer Γ A)
-            tag (if (tuple? UA) (get UA 0) 0)]
+            tag (tag-of UA)]
         (if (= tag T/Type)
           (get UA 1)
           (errorf "expected a universe Type (Type_l), but got: %s\nTip: Make sure your type expression evaluates to a Type, e.g., Type 0, Type 1, etc."
                   (print/sem UA)))))
+
+    (defn infer-binder [Γ A B]
+      (let [lvlA (check-univ Γ A)
+            fresh (gensym)
+            A-sem (eval Γ A)
+            Γ2 (ctx/add Γ fresh A-sem)
+            lvlB (check-univ Γ2 (B [:var fresh]))]
+        (ty/type (lvl/max lvlA lvlB))))
 
     (set infer
          (fn [Γ t]
@@ -84,62 +103,53 @@
                      (print/tm t))
 
              [:hole name]
-             ((meta :error-infer) name Γ)
+              ((meta :error-infer) name Γ)
 
-             [:app f x]
-             (let [fA (infer Γ f)
-                   tag (if (tuple? fA) (get fA 0) 0)]
-               (if (= tag T/Pi)
-                 (let [[_ A B] fA]
-                   (do (check Γ x A)
+              [:app f x]
+              (let [fA (infer Γ f)
+                    tag (tag-of fA)]
+                (if (= tag T/Pi)
+                  (let [[_ A B] fA]
+                    (do (check Γ x A)
                        (B (eval Γ x))))
                  (errorf "cannot apply function - expected a Pi type (Πx:A. B), but got: %s\nTip: Make sure the function has a proper Pi type annotation or can be inferred as one."
-                         (print/sem fA))))
+                          (print/sem fA))))
 
-             [:t-pi A B]
-             (let [lvlA (check-univ Γ A)
-                   fresh (gensym)
-                   A-sem (eval Γ A)
-                   Γ2 (ctx/add Γ fresh A-sem)
-                   lvlB (check-univ Γ2 (B [:var fresh]))]
-               (ty/type (lvl/max lvlA lvlB)))
+              [:t-pi A B]
+              (infer-binder Γ A B)
 
-             [:t-sigma A B]
-             (let [lvlA (check-univ Γ A)
-                   fresh (gensym)
-                   A-sem (eval Γ A)
-                   Γ2 (ctx/add Γ fresh A-sem)
-                   lvlB (check-univ Γ2 (B [:var fresh]))]
-               (ty/type (lvl/max lvlA lvlB)))
+              [:t-sigma A B]
+              (infer-binder Γ A B)
 
-             [:fst p]
-             (let [pA (infer Γ p)
-                   tag (if (tuple? pA) (get pA 0) 0)]
-               (if (= tag T/Sigma)
-                 (get pA 1)
-                 (errorf "fst projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
+              [:fst p]
+              (let [pA (infer Γ p)
+                    tag (tag-of pA)]
+                (if (= tag T/Sigma)
+                  (get pA 1)
+                  (errorf "fst projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
                          (print/sem pA))))
 
-             [:snd p]
-             (let [pA (infer Γ p)
-                   tag (if (tuple? pA) (get pA 0) 0)]
-               (if (= tag T/Sigma)
-                 (let [[_ A B] pA]
-                   (B (eval Γ [:fst p])))
-                 (errorf "snd projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
-                         (print/sem pA))))
+              [:snd p]
+              (let [pA (infer Γ p)
+                    tag (tag-of pA)]
+                (if (= tag T/Sigma)
+                  (let [[_ _ B] pA
+                        p-sem (eval Γ p)]
+                    (B (fst-sem p-sem)))
+                  (errorf "snd projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
+                          (print/sem pA))))
 
              [:pair _ _]
              (errorf "cannot infer type of pair %s\nPairs require explicit Sigma type annotation because they lack principal types.\nSuggestion: (pair a b) : (Σx:A. B)"
                      (print/tm t))
 
-             [:t-id A x y]
-             (let [A-ty (infer Γ A)
-                   A-sem (eval Γ A)
-                   tag (if (tuple? A-ty) (get A-ty 0) 0)]
-               (if (= tag T/Type)
-                 (do (check Γ x A-sem)
-                     (check Γ y A-sem)
+              [:t-id A x y]
+              (let [A-ty (infer Γ A)
+                    A-sem (eval Γ A)
+                    tag (tag-of A-ty)]
+                (if (= tag T/Type)
+                  (do (check Γ x A-sem)
+                      (check Γ y A-sem)
                      (ty/type (get A-ty 1)))
                  (errorf "Identity type (Id A x y) expects 'A' to be a universe Type, but got: %s\nThe first argument must evaluate to a Type, e.g., Type 0, Type 1, etc."
                          (print/sem A-ty))))
@@ -178,11 +188,11 @@
              [:hole name]
              ((meta :error-check) name A Γ)
 
-             [:lam body]
-             (let [tag (if (tuple? A) (get A 0) 0)]
-               (if (= tag T/Pi)
-                 (let [[_ dom cod] A
-                       fresh (gensym)
+              [:lam body]
+              (let [tag (tag-of A)]
+                (if (= tag T/Pi)
+                  (let [[_ dom cod] A
+                        fresh (gensym)
                        arg-sem (raise dom (ne/var fresh))]
                    (check (ctx/add Γ fresh dom)
                           (body [:var fresh])
@@ -190,11 +200,11 @@
                  (errorf "lambda checking failed - expected a Pi type (Πx:A. B), but got: %s\nLambda expressions can only be checked against function types."
                          (print/sem A))))
 
-             [:pair l r]
-             (let [tag (if (tuple? A) (get A 0) 0)]
-               (if (= tag T/Sigma)
-                 (let [[_ A1 B1] A]
-                   (do (check Γ l A1)
+              [:pair l r]
+              (let [tag (tag-of A)]
+                (if (= tag T/Sigma)
+                  (let [[_ A1 B1] A]
+                    (do (check Γ l A1)
                        (check Γ r (B1 (eval Γ l)))))
                  (errorf "pair checking failed - expected a Sigma type (Σx:A. B), but got: %s\nPair expressions can only be checked against Sigma product types."
                          (print/sem A))))

--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -6,6 +6,7 @@
 (import ./levels :as lvl)
 (import ./meta :as meta)
 (import ./checker :as checker)
+(import ./print :as printer)
 
 # Tags
 (def T/Type 0x01)
@@ -34,6 +35,9 @@
 (defn ty/sigma [A B] [T/Sigma A B])
 (defn ty/id [A x y] [T/Id A x y])
 (defn ty/pair [v1 v2] [T/Pair v1 v2])
+
+(def T/Type0 [T/Type 0])
+(def T/Type100 (ty/type 100))
 
 # Term constructors
 (defn tm/var [x] [:var x])
@@ -87,18 +91,18 @@
 (var print/ne nil)
 (var print/nf nil)
 (var print/tm nil)
-(var ne/print* nil)
-(var nf/print* nil)
-(var print/tm* nil)
-(var print/name-map nil)
-(var print/used-names nil)
-(var print/fresh-id 0)
 (var goals nil)
 (var goals/set-collect! nil)
 
 # NbE: raise / lower
 (var raise nil)
 (var lower nil)
+
+(defn- tag-of [x]
+  (if (tuple? x) (get x 0) 0))
+
+(defn- sem/neutral [ne]
+  [T/Neutral ne])
 
 (defn- raise/pi [A B ne]
   (fn [x]
@@ -112,16 +116,16 @@
 
 (set raise
      (fn [ty ne]
-       (let [tag (if (tuple? ty) (get ty 0) 0)]
+       (let [tag (tag-of ty)]
          (cond
-           (= tag T/Pi)
-           (let [[_ A B] ty] (raise/pi A B ne))
-           (= tag T/Sigma)
-           (let [[_ A B] ty] (raise/sigma A B ne))
-           true [T/Neutral ne]))))
+            (= tag T/Pi)
+            (let [[_ A B] ty] (raise/pi A B ne))
+            (= tag T/Sigma)
+            (let [[_ A B] ty] (raise/sigma A B ne))
+            true (sem/neutral ne)))))
 
 (defn- lower/type [sem]
-  (let [tag (if (tuple? sem) (get sem 0) 0)]
+  (let [tag (tag-of sem)]
     (cond
       (= tag T/Neutral) (nf/neut (get sem 1))
       (= tag T/Type) (nf/type (get sem 1))
@@ -129,18 +133,18 @@
                      (nf/pi (lower/type A)
                             (fn [fresh]
                               (let [arg (raise A (ne/var fresh))]
-                                (lower (ty/type 100) (B arg))))))
+                                (lower T/Type100 (B arg))))))
       (= tag T/Sigma) (let [[_ A B] sem]
                         (nf/sigma (lower/type A)
                                   (fn [fresh]
                                     (let [arg (raise A (ne/var fresh))]
-                                      (lower (ty/type 100) (B arg))))))
+                                      (lower T/Type100 (B arg))))))
       (= tag T/Id) (let [[_ A x y] sem]
                      (nf/id (lower/type A) (lower A x) (lower A y)))
       true sem)))
 
 (defn- lower/pi [A B sem]
-  (let [stag (if (tuple? sem) (get sem 0) 0)]
+  (let [stag (tag-of sem)]
     (if (= stag T/Neutral)
       (let [ne (get sem 1)]
         (nf/lam
@@ -154,7 +158,7 @@
             (lower (B arg-sem) (sem arg-sem))))))))
 
 (defn- lower/sigma [A B sem]
-  (let [stag (if (tuple? sem) (get sem 0) 0)]
+  (let [stag (tag-of sem)]
     (if (= stag T/Neutral)
       (let [ne (get sem 1)
             v1 (raise A (ne/fst ne))
@@ -164,35 +168,58 @@
         (nf/pair (lower A v1) (lower (B v1) v2))))))
 
 (defn- lower/id [ty sem]
-  (let [stag (if (tuple? sem) (get sem 0) 0)]
+  (let [stag (tag-of sem)]
     (cond
       (= stag T/Refl) (nf/refl (lower (get ty 1) (get sem 1)))
       (= stag T/Neutral) (nf/neut (get sem 1))
       true sem)))
 
 (defn- lower/neutral [sem]
-  (let [stag (if (tuple? sem) (get sem 0) 0)]
+  (let [stag (tag-of sem)]
     (if (= stag T/Neutral)
       (nf/neut (get sem 1))
       sem)))
 
 (set lower
      (fn [ty sem]
-       (let [tag (if (tuple? ty) (get ty 0) 0)]
+       (let [tag (tag-of ty)]
          (cond
-           (= tag T/Type) (lower/type sem)
-           (= tag T/Pi) (let [[_ A B] ty] (lower/pi A B sem))
+            (= tag T/Type) (lower/type sem)
+            (= tag T/Pi) (let [[_ A B] ty] (lower/pi A B sem))
            (= tag T/Sigma) (let [[_ A B] ty] (lower/sigma A B sem))
            (= tag T/Id) (lower/id ty sem)
            (= tag T/Neutral) (lower/neutral sem)
            true sem))))
 
+(let [pp (printer/make {:T/Type T/Type
+                        :T/Pi T/Pi
+                        :T/Sigma T/Sigma
+                        :T/Id T/Id
+                        :T/Refl T/Refl
+                        :T/Neutral T/Neutral
+                        :T/Pair T/Pair
+                        :NF/Neut NF/Neut
+                        :NF/Lam NF/Lam
+                        :NF/Pi NF/Pi
+                        :NF/Sigma NF/Sigma
+                        :NF/Type NF/Type
+                        :NF/Pair NF/Pair
+                        :NF/Id NF/Id
+                        :NF/Refl NF/Refl
+                        :ty/type ty/type
+                        :lower lower
+                        :lvl/value lvl/value})]
+  (set print/sem (pp :print/sem))
+  (set print/ne (pp :print/ne))
+  (set print/nf (pp :print/nf))
+  (set print/tm (pp :print/tm)))
+
 # Definitional equality
 (var sem-eq nil)
 
 (defn- sem-eq/type [ty v1 v2]
-  (let [t1 (if (tuple? v1) (get v1 0) 0)
-        t2 (if (tuple? v2) (get v2 0) 0)]
+  (let [t1 (tag-of v1)
+        t2 (tag-of v2)]
     (cond
       (and (= t1 T/Type) (= t2 T/Type))
       (lvl/eq? (get v1 1) (get v2 1))
@@ -218,30 +245,34 @@
       true (= v1 v2))))
 
 (defn- sem-eq/pi [A B v1 v2]
-  (let [fresh (gensym)
-        arg-sem (raise A (ne/var fresh))
-        t1 (if (tuple? v1) (get v1 0) 0)
-        t2 (if (tuple? v2) (get v2 0) 0)]
+  (let [t1 (tag-of v1)
+        t2 (tag-of v2)]
     (cond
       (and (= t1 T/Neutral) (= t2 T/Neutral))
       (= (get v1 1) (get v2 1))
 
       (= t1 T/Neutral)
-      (sem-eq (B arg-sem)
-              (raise (B arg-sem) (ne/app (get v1 1) (lower A arg-sem)))
-              (v2 arg-sem))
+      (let [fresh (gensym)
+            arg-sem (raise A (ne/var fresh))]
+        (sem-eq (B arg-sem)
+                (raise (B arg-sem) (ne/app (get v1 1) (lower A arg-sem)))
+                (v2 arg-sem)))
 
       (= t2 T/Neutral)
-      (sem-eq (B arg-sem)
-              (v1 arg-sem)
-              (raise (B arg-sem) (ne/app (get v2 1) (lower A arg-sem))))
+      (let [fresh (gensym)
+            arg-sem (raise A (ne/var fresh))]
+        (sem-eq (B arg-sem)
+                (v1 arg-sem)
+                (raise (B arg-sem) (ne/app (get v2 1) (lower A arg-sem)))))
 
       true
-      (sem-eq (B arg-sem) (v1 arg-sem) (v2 arg-sem)))))
+      (let [fresh (gensym)
+            arg-sem (raise A (ne/var fresh))]
+        (sem-eq (B arg-sem) (v1 arg-sem) (v2 arg-sem))))))
 
 (defn- sem-eq/sigma [A B v1 v2]
-  (let [t1 (if (tuple? v1) (get v1 0) 0)
-        t2 (if (tuple? v2) (get v2 0) 0)]
+  (let [t1 (tag-of v1)
+        t2 (tag-of v2)]
     (cond
       (and (= t1 T/Neutral) (= t2 T/Neutral))
       (= (get v1 1) (get v2 1))
@@ -249,16 +280,16 @@
       (= t1 T/Neutral)
       (let [[_ l2 r2] v2
             ne1 (get v1 1)
-            p1-fst [T/Neutral (ne/fst ne1)]
-            p1-snd [T/Neutral (ne/snd ne1)]]
+            p1-fst (sem/neutral (ne/fst ne1))
+            p1-snd (sem/neutral (ne/snd ne1))]
         (and (sem-eq A p1-fst l2)
              (sem-eq (B p1-fst) p1-snd r2)))
 
       (= t2 T/Neutral)
       (let [[_ l1 r1] v1
             ne2 (get v2 1)
-            p2-fst [T/Neutral (ne/fst ne2)]
-            p2-snd [T/Neutral (ne/snd ne2)]]
+            p2-fst (sem/neutral (ne/fst ne2))
+            p2-snd (sem/neutral (ne/snd ne2))]
         (and (sem-eq A l1 p2-fst)
              (sem-eq (B l1) r1 p2-snd)))
 
@@ -267,9 +298,9 @@
         (and (sem-eq A l1 l2)
              (sem-eq (B l1) r1 r2))))))
 
-(defn- sem-eq/id [A x y v1 v2]
-  (let [t1 (if (tuple? v1) (get v1 0) 0)
-        t2 (if (tuple? v2) (get v2 0) 0)]
+(defn- sem-eq/id [A v1 v2]
+  (let [t1 (tag-of v1)
+        t2 (tag-of v2)]
     (cond
       (and (= t1 T/Refl) (= t2 T/Refl))
       (sem-eq A (get v1 1) (get v2 1))
@@ -281,14 +312,16 @@
 
 (set sem-eq
      (fn [ty v1 v2]
-       "Check if two semantic values are equal at given type (with eta)"
-       (let [tag (if (tuple? ty) (get ty 0) 0)]
-         (cond
-           (= tag T/Type) (sem-eq/type ty v1 v2)
-           (= tag T/Pi) (let [[_ A B] ty] (sem-eq/pi A B v1 v2))
-           (= tag T/Sigma) (let [[_ A B] ty] (sem-eq/sigma A B v1 v2))
-           (= tag T/Id) (let [[_ A x y] ty] (sem-eq/id A x y v1 v2))
-           true (= v1 v2)))))
+        "Check if two semantic values are equal at given type (with eta)"
+       (if (= v1 v2)
+         true
+         (let [tag (tag-of ty)]
+           (cond
+             (= tag T/Type) (sem-eq/type ty v1 v2)
+             (= tag T/Pi) (let [[_ A B] ty] (sem-eq/pi A B v1 v2))
+             (= tag T/Sigma) (let [[_ A B] ty] (sem-eq/sigma A B v1 v2))
+             (= tag T/Id) (let [[_ A _ _] ty] (sem-eq/id A v1 v2))
+             true false)))))
 
 # Evaluator
 (var eval nil)
@@ -304,9 +337,9 @@
 (defn- eval/app [Γ f x]
   (let [fv (eval Γ f)
         xv (eval Γ x)]
-    (let [tag (if (tuple? fv) (get fv 0) 0)]
+    (let [tag (tag-of fv)]
       (if (= tag T/Neutral)
-        [T/Neutral (ne/app (get fv 1) (lower [T/Type 0] xv))]
+        (sem/neutral (ne/app (get fv 1) (lower T/Type0 xv)))
         (fv xv)))))
 
 (defn- eval/t-pi [Γ A B]
@@ -320,19 +353,19 @@
 
 (defn- eval/fst [Γ p]
   (let [v (eval Γ p)
-        tag (if (tuple? v) (get v 0) 0)]
+        tag (tag-of v)]
     (cond
       (= tag T/Pair) (get v 1)
-      (= tag T/Neutral) [T/Neutral (ne/fst (get v 1))]
+      (= tag T/Neutral) (sem/neutral (ne/fst (get v 1)))
       true (errorf "fst expects a pair value (Σ type), but got: %s"
                    (print/sem v)))))
 
 (defn- eval/snd [Γ p]
   (let [v (eval Γ p)
-        tag (if (tuple? v) (get v 0) 0)]
+        tag (tag-of v)]
     (cond
       (= tag T/Pair) (get v 2)
-      (= tag T/Neutral) [T/Neutral (ne/snd (get v 1))]
+      (= tag T/Neutral) (sem/neutral (ne/snd (get v 1)))
       true (errorf "snd expects a pair value (Σ type), but got: %s"
                    (print/sem v)))))
 
@@ -349,15 +382,15 @@
         Pv (eval Γ P)
         dv (eval Γ d)
         yv (eval Γ y)
-        tag (if (tuple? pv) (get pv 0) 0)]
+        tag (tag-of pv)]
     (cond
       (= tag T/Refl)
       (let [zv (get pv 1)]
         (if (sem-eq Av zv xv) dv
-          [T/Neutral (ne/J Av xv Pv dv yv pv)]))
+          (sem/neutral (ne/J Av xv Pv dv yv pv))))
 
       (= tag T/Neutral)
-      [T/Neutral (ne/J Av xv Pv dv yv pv)]
+      (sem/neutral (ne/J Av xv Pv dv yv pv))
 
       true (errorf "J eliminator requires a proof of identity (Id A x y), but got: %s"
                    (print/sem pv)))))
@@ -400,269 +433,30 @@
 (var check nil)
 (var subtype nil)
 
-
-(defn- print/reset-state! []
-  (set print/fresh-id 0)
-  (set print/name-map @{})
-  (set print/used-names @{}))
-
-(defn- print/mark-used! [name]
-  (put print/used-names name true)
-  name)
-
-(defn- print/used? [name]
-  (get print/used-names name))
-
-(defn- print/internal-name? [x]
-  (let [s (string x)]
-    (and (> (length s) 0)
-         (= (s 0) (chr "_")))))
-
-(defn- print/alpha-name [n]
-  (let [letters "abcdefghijklmnopqrstuvwxyz"]
-    (defn recur [k]
-      (let [q (div k 26)
-            r (% k 26)
-            ch (string/slice letters r (+ r 1))]
-        (if (= q 0)
-          ch
-          (string (recur (- q 1)) ch))))
-    (recur n)))
-
-(defn- print/fresh-name []
-  (var out nil)
-  (while (nil? out)
-    (let [candidate (print/alpha-name print/fresh-id)]
-      (++ print/fresh-id)
-      (when (not (print/used? candidate))
-        (set out (print/mark-used! candidate)))))
-  out)
-
-(defn- print/disambiguate [preferred]
-  (if (not (print/used? preferred))
-    (print/mark-used! preferred)
-    (do
-      (var out nil)
-      (var n 1)
-      (while (nil? out)
-        (let [candidate (string preferred n)]
-          (if (print/used? candidate)
-            (++ n)
-            (set out (print/mark-used! candidate)))))
-      out)))
-
-(defn- print/name [x]
-  (or (get print/name-map x)
-      (let [preferred (string x)
-            out (if (print/internal-name? x)
-                  (print/fresh-name)
-                  (print/disambiguate preferred))]
-        (put print/name-map x out)
-        out)))
-
-(defn- print/wrap [s]
-  (string "(" s ")"))
-
-(defn- print/atomic-nf? [nf]
-  (match nf
-    [NF/Type _] true
-    [NF/Neut [:nvar _]] true
-    _ false))
-
-(defn- print/atomic-ne? [ne]
-  (match ne
-    [:nvar _] true
-    _ false))
-
-(defn- print/nf-arg [nf]
-  (let [rendered (nf/print* nf)]
-    (if (print/atomic-nf? nf) rendered (print/wrap rendered))))
-
-(defn- print/ne-arg [ne]
-  (let [rendered (ne/print* ne)]
-    (if (print/atomic-ne? ne) rendered (print/wrap rendered))))
-
-(defn- print/atomic-tm? [tm]
-  (match tm
-    [:var _] true
-    [:type _] true
-    [:hole _] true
-    _ false))
-
-(defn- print/tm-arg [tm]
-  (let [rendered (print/tm* tm)]
-    (if (print/atomic-tm? tm) rendered (print/wrap rendered))))
-
-(set ne/print* (fn [ne]
-  (match ne
-    [:nvar x] (print/name x)
-    [:napp f x] (string (print/ne-arg f) " " (print/nf-arg x))
-    [:nfst p] (string "fst " (print/ne-arg p))
-    [:nsnd p] (string "snd " (print/ne-arg p))
-    [:nJ A x P d y p]
-    (string "J "
-            (print/nf-arg A) " "
-            (print/nf-arg x) " "
-            (print/nf-arg P) " "
-            (print/nf-arg d) " "
-            (print/nf-arg y) " "
-            (print/ne-arg p))
-    _ (string/format "%v" ne))))
-
-(set nf/print* (fn [nf]
-  (match nf
-    [NF/Type l]
-    (string "Type" (if (or (int? l) (tuple? l)) (lvl/value l) (string/format "%v" l)))
-
-    [NF/Pi A B]
-    (let [x (print/fresh-name)]
-      (string "Pi(" x " : " (nf/print* A) "). " (nf/print* (B x))))
-
-    [NF/Sigma A B]
-    (let [x (print/fresh-name)]
-      (string "Sigma(" x " : " (nf/print* A) "). " (nf/print* (B x))))
-
-    [NF/Id A x y]
-    (string "Id " (print/nf-arg A) " " (print/nf-arg x) " " (print/nf-arg y))
-
-    [NF/Refl x]
-    (string "refl " (print/nf-arg x))
-
-    [NF/Pair l r]
-    (string "(" (nf/print* l) ", " (nf/print* r) ")")
-
-    [NF/Lam body]
-    (let [x (print/fresh-name)]
-      (string "λ" x ". " (nf/print* (body x))))
-
-    [NF/Neut ne]
-    (ne/print* ne)
-
-    _
-    (string/format "%v" nf))))
-
-(set print/tm* (fn [tm]
-  (match tm
-    [:var x]
-    (print/name x)
-
-    [:app f x]
-    (string (print/tm-arg f) " " (print/tm-arg x))
-
-    [:type l]
-    (string "Type" l)
-
-    [:lam body]
-    (let [x (print/fresh-name)]
-      (string "λ" x ". " (print/tm* (body [:var x]))))
-
-    [:t-pi A B]
-    (let [x (print/fresh-name)]
-      (string "Pi(" x " : " (print/tm* A) "). " (print/tm* (B [:var x]))))
-
-    [:t-sigma A B]
-    (let [x (print/fresh-name)]
-      (string "Sigma(" x " : " (print/tm* A) "). " (print/tm* (B [:var x]))))
-
-    [:pair l r]
-    (string "(" (print/tm* l) ", " (print/tm* r) ")")
-
-    [:fst p]
-    (string "fst " (print/tm-arg p))
-
-    [:snd p]
-    (string "snd " (print/tm-arg p))
-
-    [:t-id A x y]
-    (string "Id " (print/tm-arg A) " " (print/tm-arg x) " " (print/tm-arg y))
-
-    [:t-refl x]
-    (string "refl " (print/tm-arg x))
-
-    [:t-J A x P d y p]
-    (string "J "
-            (print/tm-arg A) " "
-            (print/tm-arg x) " "
-            (print/tm-arg P) " "
-            (print/tm-arg d) " "
-            (print/tm-arg y) " "
-            (print/tm-arg p))
-
-    [:hole name]
-    (if name (string "?" name) "?")
-
-    _
-    (string/format "%v" tm))))
-
-(set print/ne (fn [ne]
-  (let [saved-id print/fresh-id
-        saved-map print/name-map
-        saved-used print/used-names]
-    (print/reset-state!)
-    (def out (ne/print* ne))
-    (set print/fresh-id saved-id)
-    (set print/name-map saved-map)
-    (set print/used-names saved-used)
-    out)))
-
-(set print/nf (fn [nf]
-  (let [saved-id print/fresh-id
-        saved-map print/name-map
-        saved-used print/used-names]
-    (print/reset-state!)
-    (def out (nf/print* nf))
-    (set print/fresh-id saved-id)
-    (set print/name-map saved-map)
-    (set print/used-names saved-used)
-    out)))
-
-(set print/tm (fn [tm]
-  (let [saved-id print/fresh-id
-        saved-map print/name-map
-        saved-used print/used-names]
-    (print/reset-state!)
-    (def out (print/tm* tm))
-    (set print/fresh-id saved-id)
-    (set print/name-map saved-map)
-    (set print/used-names saved-used)
-    out)))
-
-(set print/sem
-     (fn [sem]
-       (let [tag (if (tuple? sem) (get sem 0) 0)]
-         (cond
-           (= tag T/Neutral) (print/ne (get sem 1))
-           (= tag T/Type) (print/nf (lower/type sem))
-           (= tag T/Pi) (print/nf (lower/type sem))
-           (= tag T/Sigma) (print/nf (lower/type sem))
-           (= tag T/Id) (print/nf (lower/type sem))
-           (= tag T/Refl) (string "refl " (print/sem (get sem 1)))
-           (= tag T/Pair) (string "(" (print/sem (get sem 1)) ", " (print/sem (get sem 2)) ")")
-           true (string/format "%v" sem)))))
-
 (let [meta-state (meta/make {:ty/type ty/type
                              :lower lower
                              :ctx/lookup ctx/lookup
                              :print/sem print/sem})
-      checker-state (checker/make {:T/Type T/Type
-                                   :T/Pi T/Pi
-                                   :T/Sigma T/Sigma
-                                   :ty/type ty/type
-                                   :ty/id ty/id
-                                   :lvl/<= lvl/leq
-                                   :lvl/max (fn [l1 l2] (max (lvl/value l1) (lvl/value l2)))
-                                   :lvl/succ (fn [l] (inc (lvl/value l)))
-                                   :sem-eq sem-eq
-                                   :eval eval
-                                   :raise raise
-                                   :lower lower
-                                   :ctx/empty ctx/empty
-                                   :ctx/add ctx/add
-                                   :ctx/lookup ctx/lookup
-                                   :ne/var ne/var
-                                   :print/sem print/sem
-                                   :print/tm print/tm
-                                   :meta meta-state})]
+        checker-state (checker/make {:T/Type T/Type
+                                    :T/Pi T/Pi
+                                    :T/Sigma T/Sigma
+                                    :T/Pair T/Pair
+                                    :T/Neutral T/Neutral
+                                    :ty/type ty/type
+                                    :ty/id ty/id
+                                    :lvl/<= lvl/leq
+                                    :lvl/max lvl/max*
+                                    :lvl/succ lvl/succ
+                                    :sem-eq sem-eq
+                                    :eval eval
+                                    :raise raise
+                                    :ctx/add ctx/add
+                                    :ctx/lookup ctx/lookup
+                                    :ne/var ne/var
+                                    :ne/fst ne/fst
+                                    :print/sem print/sem
+                                    :print/tm print/tm
+                                    :meta meta-state})]
   (set goals (meta-state :goals))
   (set goals/set-collect! (meta-state :set-collect!))
   (set infer (checker-state :infer))
@@ -670,7 +464,7 @@
   (set subtype (checker-state :subtype)))
 
 (defn type-eq [Γ A B]
-  (= (eval Γ A) (eval Γ B)))
+  (sem-eq T/Type100 (eval Γ A) (eval Γ B)))
 
 (defn term-eq [Γ A t u]
   (or (= t u)

--- a/src/elab.janet
+++ b/src/elab.janet
@@ -174,11 +174,6 @@
           rest (slice params 1)]
       [:lam (fn [x] (elab/lam-chain (env/extend env name x) sig-env rest body))])))
 
-(defn list/head [xs]
-  (if (and (> (length xs) 0) (l/node/atom? (xs 0)))
-    (l/node/atom (xs 0))
-    nil))
-
 (defn list/expect-arity [form xs expected]
   (let [got (length xs)]
     (when (not= got expected)
@@ -210,6 +205,32 @@
         body (list/parse-body (slice tail 1) form)]
     [binders body]))
 
+(defn list/parse-lam-binders [spec]
+  (cond
+    (and (tuple? spec) (= (spec 0) :atom))
+    @([:bind (spec 1) nil])
+
+    (and (tuple? spec) (= (spec 0) :list))
+    (let [xs (spec 1)]
+      (if (l/bind/single-spec? spec)
+        @[(l/bind/from-node spec)]
+        (map (fn [item]
+               (match item
+                 [:atom name] [:bind name nil]
+                 _ (l/bind/from-node item)))
+             xs)))
+
+    true
+    (errorf "invalid lambda binder specification: %v\nSupported formats:\n  x - single untyped binder\n  (x y z) - multiple untyped binders\n  (x: A) - single typed binder\n  ((x: A) (y: B)) - multiple typed binders" spec)))
+
+(defn list/parse-lam-body [xs]
+  (when (< (length xs) 3)
+    (errorf "lambda needs binders and a body: %v" [:list xs]))
+  (let [tail (slice xs 1)
+        binders (list/parse-lam-binders (tail 0))
+        body (list/parse-body (slice tail 1) "lambda")]
+    [binders body]))
+
 (defn list/parse-ann-binder [node]
   (match node
     [:list xs]
@@ -226,7 +247,7 @@
     (elab/pi-chain env sig-env binders body)))
 
 (defn elab/list-lam [env sig-env xs]
-  (let [[binders body] (list/parse-binders-body xs "lambda")]
+  (let [[binders body] (list/parse-lam-body xs)]
     (elab/lam-chain env sig-env binders body)))
 
 (defn elab/list-lam-ann [env sig-env xs]
@@ -315,9 +336,12 @@
 (defn elab/list [env sig-env node xs]
   (if (or (l/term/forall? node) (l/term/arrow? node))
     (elab/list-pi env sig-env node)
-    (if-let [handler (get elab/list-dispatch (list/head xs))]
-      (handler env sig-env xs)
-      (elab/app-list env sig-env xs))))
+    (let [head (if (and (> (length xs) 0) (l/node/atom? (xs 0)))
+                 (l/node/atom (xs 0))
+                 nil)]
+      (if-let [handler (get elab/list-dispatch head)]
+        (handler env sig-env xs)
+        (elab/app-list env sig-env xs)))))
 
 (set elab/term
      (fn [env sig-env node]
@@ -354,15 +378,12 @@
                 binders)]
     [out final-env]))
 
-(defn seq/contains? [xs x]
-  (not (nil? (find-index |(= $ x) xs))))
-
 (defn clause/vars [patterns]
   "Collect unique pattern variables from clause patterns."
   (defn collect [pat seen]
     (match pat
       [:pat/var x]
-      (if (or (= x "_") (seq/contains? seen x))
+      (if (or (= x "_") (find |(= $ x) seen))
         seen
         [;seen x])
       [:pat/con _ args]
@@ -380,9 +401,6 @@
       [:core/clause patterns (elab/term env sig-env body)])
     _
     (errorf "invalid clause: %v" clause)))
-
-(defn text/contains? [s sub]
-  (not (nil? (string/find sub (string s)))))
 
 (defn node/atom/new [tok]
   [:atom tok])
@@ -465,12 +483,6 @@
             params (map l/bind/from-node (slice items 1 (length items)))]
         [name params]))))
 
-(defn entry/line [entry]
-  (entry 1))
-
-(defn entry/children [entry]
-  (entry 2))
-
 (defn items/eq-index [items]
   (find-index |(and (tuple? $) (= ($ 0) :atom) (= ($ 1) "=")) items))
 
@@ -479,28 +491,28 @@
     (slice items 0 eq-index)
     items))
 
-(defn items->node [items]
-  (if (and (= (length items) 1)
-           (tuple? (items 0))
-           (= ((items 0) 0) :list))
-    (items 0)
-    [:list items]))
-
 (defn field/binder-from-line [line]
   (let [lhs-items (items/lhs-of-eq (line/items line))
-        node (items->node lhs-items)]
+        node (if (and (= (length lhs-items) 1)
+                      (tuple? (lhs-items 0))
+                      (= ((lhs-items 0) 0) :list))
+               (lhs-items 0)
+               [:list lhs-items])]
     (if (l/bind/single-spec? node)
       (l/bind/from-node node)
       nil)))
 
 (defn entry/field-binders [entry]
-  (map |(field/binder-from-line (entry/line $)) (entry/children entry)))
-
-(defn seq/all? [pred xs]
-  (reduce (fn [acc x] (and acc (pred x))) true xs))
+  (map |(field/binder-from-line ($ 1)) (entry 2)))
 
 (defn seq/concat [xs ys]
   (reduce (fn [acc y] [;acc y]) xs ys))
+
+(defn node/list [items]
+  [:list items])
+
+(defn clause/list [items]
+  (node/list (seq/concat @[[:atom "|"]] items)))
 
 (defn term/sigma-from-binders [binders]
   (when (zero? (length binders))
@@ -525,22 +537,20 @@
 (defn term/app-head [head args]
   (if (zero? (length args))
     [:atom head]
-    [:list (reduce (fn [acc a] [;acc [:atom a]]) @[[:atom head]] args)]))
+    (node/list (reduce (fn [acc a] [;acc [:atom a]]) @[[:atom head]] args))))
 
 (defn form/def-from-type+clauses [name ann clauses]
-  [:list (reduce (fn [acc x] [;acc x])
-                 @[[:atom "def"] [:atom (string name ":")] ann]
-                 clauses)])
+  (node/list (seq/concat @[[:atom "def"] [:atom (string name ":")] ann]
+                         clauses)))
 
 (defn form/clause [patterns body]
-  [:list (reduce (fn [acc x] [;acc x])
-                 (reduce (fn [acc p] [;acc [:atom p]])
-                         @[[:atom "|"]]
-                         patterns)
-                 @[[:atom "="] body])])
+  (clause/list
+    (seq/concat
+      (map |[:atom $] patterns)
+      @[[:atom "="] body])))
 
 (defn entry/child-binder-node [entry]
-  (let [items0 (line/items (entry/line entry))
+  (let [items0 (line/items (entry 1))
         eq-index (items/eq-index items0)
         lhs-items (if (nil? eq-index)
                     items0
@@ -552,9 +562,9 @@
       [:list lhs-items])))
 
 (defn entry/ctor-items [entry]
-  (let [base (line/items (entry/line entry))
-        child-binders (map entry/child-binder-node (entry/children entry))]
-    (reduce (fn [acc b] [;acc b]) base child-binders)))
+  (let [base (line/items (entry 1))
+        child-binders (map entry/child-binder-node (entry 2))]
+    (seq/concat base child-binders)))
 
 (defn atom/type-token? [node]
   (and (tuple? node)
@@ -609,19 +619,11 @@
   (let [items (entry/ctor-items entry)
         eq-index (items/eq-index items)]
     (if (nil? eq-index)
-      [:list (reduce (fn [acc x] [;acc x])
-                     @[[:atom "|"]]
-                     items)]
+      (clause/list items)
       (let [selectors (slice items 0 eq-index)
             rhs (slice items (+ eq-index 1) (length items))
             full-selectors (selectors/for-clause params selectors rhs)]
-        [:list (reduce (fn [acc x] [;acc x])
-                       @[[:atom "|"]]
-                       (reduce (fn [acc x] [;acc x])
-                               (reduce (fn [acc x] [;acc x])
-                                       full-selectors
-                                       @[[:atom "="]])
-                               rhs))]))))
+        (clause/list (seq/concat (seq/concat full-selectors @[[:atom "="]]) rhs))))))
 
 (defn patterns/normalize-arity [pat-items arity]
   (cond
@@ -631,43 +633,35 @@
     true pat-items))
 
 (defn entry/func-clause-node [arity entry]
-  (let [items (line/items (entry/line entry))
+  (let [items (line/items (entry 1))
         eq-index (items/eq-index items)]
     (if (nil? eq-index)
-      [:list (reduce (fn [acc x] [;acc x])
-                     @[[:atom "|"]]
-                     items)]
+      (clause/list items)
       (let [patterns0 (slice items 0 eq-index)
             body (slice items (+ eq-index 1) (length items))
             patterns (patterns/normalize-arity patterns0 arity)]
-        [:list (reduce (fn [acc x] [;acc x])
-                       @[[:atom "|"]]
-                       (reduce (fn [acc x] [;acc x])
-                               (reduce (fn [acc x] [;acc x])
-                                       patterns
-                                       @[[:atom "="]])
-                               body))]))))
+        (clause/list (seq/concat (seq/concat patterns @[[:atom "="]]) body))))))
 
 (defn record/function-type-line? [line]
   (let [t (string/trim (string line))]
-    (or (text/contains? t "->")
-        (text/contains? t "→")
-        (text/contains? t "∀"))))
+    (or (string/find "->" t)
+        (string/find "→" t)
+        (string/find "∀" t))))
 
 (defn record/sigma-shape? [entries]
   (and (= (length entries) 1)
-       (> (length (entry/children (entries 0))) 0)
-       (let [ctor-items (line/items (entry/line (entries 0)))
+       (> (length ((entries 0) 2)) 0)
+       (let [ctor-items (line/items ((entries 0) 1))
              ctor-ok (and (> (length ctor-items) 0)
                           (tuple? (ctor-items 0))
                           (= ((ctor-items 0) 0) :atom)
                           (nil? (items/eq-index ctor-items)))
              binders (entry/field-binders (entries 0))]
-         (and ctor-ok (seq/all? |(not (nil? $)) binders)))))
+         (and ctor-ok (all |(not (nil? $)) binders)))))
 
 (defn record->sigma-forms [name params entries]
   (let [ctor-entry (entries 0)
-        ctor-items (line/items (entry/line ctor-entry))
+        ctor-items (line/items (ctor-entry 1))
         ctor-name ((ctor-items 0) 1)
         fields (entry/field-binders ctor-entry)
         sigma-body (term/sigma-from-binders fields)
@@ -691,36 +685,30 @@
           is-func
           (or (not (nil? rhs))
               (and (> (length entries) 0)
-                   (record/function-type-line? (entry/line (entries 0)))))]
+                   (record/function-type-line? ((entries 0) 1))))]
       (if sigma-record?
         (record->sigma-forms name params entries)
         (if is-func
-        (let [ann-text (if rhs rhs (entry/line (entries 0)))
-              ann (line/term ann-text)
-              [fn-params _] (l/term/split-pi ann)
-              arity (length fn-params)
-              clause-entries (if rhs entries (slice entries 1 (length entries)))
-              clauses (map |(entry/func-clause-node arity $) clause-entries)
-              head-nodes
-              (if (zero? (length param-nodes))
-                @[[:atom "def"] [:atom (string name ":")] ann]
-                (reduce (fn [acc x] [;acc x])
-                        (reduce (fn [acc p] [;acc p])
-                                @[[:atom "def"] [:atom name]]
-                                param-nodes)
-                        @[[:atom ":"] ann]))]
-          @[[:list (reduce (fn [acc x] [;acc x])
-                           head-nodes
-                           clauses)]])
+          (let [ann-text (if rhs rhs ((entries 0) 1))
+                ann (line/term ann-text)
+                [fn-params _] (l/term/split-pi ann)
+                arity (length fn-params)
+                clause-entries (if rhs entries (slice entries 1 (length entries)))
+                clauses (map |(entry/func-clause-node arity $) clause-entries)
+                head-nodes
+                (if (zero? (length param-nodes))
+                  @[[:atom "def"] [:atom (string name ":")] ann]
+                  (seq/concat (seq/concat @[[:atom "def"] [:atom name]]
+                                          param-nodes)
+                              @[[:atom ":"] ann]))]
+            @[(node/list (seq/concat head-nodes clauses))])
           (let [sort (if rhs (line/term rhs) [:atom "Type"])
-                clauses (map |(entry/data-clause-node params $) entries)]
-            @[[:list (reduce (fn [acc x] [;acc x])
-                             (reduce (fn [acc p] [;acc p])
-                                     @[[:atom "data"] [:atom name]]
-                                     param-nodes)
-                             (reduce (fn [acc c] [;acc c])
-                                     @[[:atom ":"] sort]
-                                     clauses))]]))))
+                clauses (map |(entry/data-clause-node params $) entries)
+                data-nodes (seq/concat (seq/concat @[[:atom "data"] [:atom name]]
+                                                   param-nodes)
+                                       (seq/concat @[[:atom ":"] sort]
+                                                   clauses))]
+            @[(node/list data-nodes)]))))
     _
     (errorf "expected :decl/record, got: %v" decl)))
 

--- a/src/frontend/sexpr/lower.janet
+++ b/src/frontend/sexpr/lower.janet
@@ -21,9 +21,6 @@
 (defn node/atom= [node tok]
   (and (node/atom? node) (= (node 1) tok)))
 
-(defn node/atom/new [tok]
-  [:atom tok])
-
 (defn record/entry/lower [node]
   (when (not (node/list? node))
     (errorf "record entry must be a list, got: %v" node))
@@ -90,7 +87,7 @@
     @[(bind/from-node spec)]
     (if (node/list? spec)
       (map bind/from-node (node/list-items spec))
-      (errorf "invalid forall binder specification: %v\nSupported formats:\n  (x: Type) - single binder\n  (x: Type y: Type) - multiple binders in a list\n  ((x: Type) (y: Type)) - multiple binders as separate specs" spec))))
+      (errorf "invalid forall binder specification: %v\nSupported formats:\n  (x: Type) - single binder\n  (x: Type, y: Type) - multiple binders in a list\n  ((x: Type) (y: Type)) - multiple binders as separate specs" spec))))
 
 (defn term/forall? [node]
   (and (node/list? node)
@@ -130,18 +127,6 @@
                 [:list (slice xs 2 n)]))]
         [(binders/from-spec binder-spec) body]))))
 
-(defn find-index [pred xs]
-  (defn find-iter [i xs]
-    (if (empty? xs)
-      nil
-      (if (pred (first xs))
-        i
-        (find-iter (+ i 1) (slice xs 1)))))
-  (find-iter 0 xs))
-
-(defn seq/contains? [xs x]
-  (not (nil? (find-index |(= $ x) xs))))
-
 (defn assoc/get [pairs key]
   (defn scan [i]
     (if (< i 0)
@@ -152,24 +137,18 @@
           (scan (- i 1))))))
   (scan (- (length pairs) 1)))
 
-(defn assoc/has? [pairs key]
-  (not (nil? (assoc/get pairs key))))
-
 (defn data/env-get [data-env name]
   (assoc/get data-env name))
 
 (defn data/env-extend [data-env name ctors]
   [;data-env [name ctors]])
 
-(defn seq/concat [xs ys]
-  (reduce (fn [acc y] [;acc y]) xs ys))
-
 (defn term/split-pi [node]
   (defn split-loop [cur index binders]
     (cond
       (term/forall? cur)
       (let [[bs body] (term/unpack-forall cur)]
-        (split-loop body index (seq/concat binders bs)))
+        (split-loop body index (tuple/join binders bs)))
 
       (term/arrow? cur)
       (let [[dom cod] (term/unpack-arrow cur)
@@ -201,8 +180,8 @@
     (cond
       (node/atom? node)
       (let [tok (node/atom node)]
-        (if (and (assoc/has? var-types tok)
-                 (not (seq/contains? seen tok)))
+        (if (and (assoc/get var-types tok)
+                 (nil? (find-index |(= $ tok) seen)))
           [[;seen tok] [;out tok]]
           [seen out]))
 
@@ -217,7 +196,7 @@
 (defn pat/from-term [term pat-var-set]
   (match term
     [:atom tok]
-    (if (seq/contains? pat-var-set tok)
+    (if (not (nil? (find-index |(= $ tok) pat-var-set)))
       [:pat/var tok]
       [:pat/con tok @[]])
 
@@ -237,7 +216,7 @@
     [:pat/con c args]
     (if (zero? (length args))
       [:atom c]
-      [:list (seq/concat @[[:atom c]] (map pat/to-term args))])
+      [:list (tuple/join @[[:atom c]] (map pat/to-term args))])
     [:pat/impossible]
     (errorf "cannot convert impossible pattern to term\nThe 'impossible' pattern is internal-only and cannot be converted back to a term")
     _
@@ -246,14 +225,14 @@
 (defn term/build-data-app [name args]
   (if (zero? (length args))
     [:atom name]
-    [:list (seq/concat @[[:atom name]] args)]))
+    [:list (tuple/join @[[:atom name]] args)]))
 
 (defn term/build-forall [binders body]
   (defn fold-binders [acc binder]
     (let [name (if (>= (length binder) 2) (binder 1) "_")
           ty (if (>= (length binder) 3) (binder 2) [:atom "Type"])
-          binder-node [:list @[(node/atom/new (string name ":")) ty]]]
-      [:list @[(node/atom/new "forall") binder-node (node/atom/new ".") acc]]))
+          binder-node [:list @[[ :atom (string name ":") ] ty]]]
+      [:list @[[ :atom "forall" ] binder-node [ :atom "." ] acc]]))
   (reduce fold-binders body (reverse binders)))
 
 (defn decl/parse-name-and-ann [nodes]
@@ -377,14 +356,14 @@
   "Keep last binder for each name (reverse first so last wins)."
   (let [step (fn [[seen out] b]
                (let [name (b 1)]
-                 (if (seq/contains? seen name)
-                   [seen out]
-                   [[;seen name] [;out b]])))
+                  (if (not (nil? (find-index |(= $ name) seen)))
+                    [seen out]
+                    [[;seen name] [;out b]])))
         [_ out] (reduce step [@[] @[]] (reverse binders))]
     (reverse out)))
 
 (defn term/build-id [ty lhs rhs]
-  [:list @[(node/atom/new "Id") ty lhs rhs]])
+  [:list @[[ :atom "Id" ] ty lhs rhs]])
 
 (defn ctor/ford-eqs [data-params ret-args]
   (let [n (length data-params)]
@@ -403,16 +382,16 @@
 (defn ctor/ford-encoded [data-name data-params pat-binders ctor-params eq-binders]
   (let [data-param-terms (map |[:atom ($ 1)] data-params)
         result-term (term/build-data-app data-name data-param-terms)
-        base-binders (binders/unique-by-name (seq/concat data-params (seq/concat pat-binders ctor-params)))
-        all-binders (seq/concat base-binders eq-binders)]
+        base-binders (binders/unique-by-name (tuple/join data-params pat-binders ctor-params))
+        all-binders (tuple/join base-binders eq-binders)]
     (term/build-forall all-binders result-term)))
 
 (defn ctor/lower-indexed [data-name data-params name ctor-binders ret-args]
-  (let [var-types (binders/name->type (binders/unique-by-name (seq/concat data-params ctor-binders)))
+  (let [var-types (binders/name->type (binders/unique-by-name (tuple/join data-params ctor-binders)))
         ordered-vars (term/collect-var-order ret-args var-types)
         pat-var-set ordered-vars
         pat-binders (map |[:bind $ (assoc/get var-types $)] ordered-vars)
-        ctor-params (filter |(not (seq/contains? pat-var-set ($ 1))) ctor-binders)
+        ctor-params (filter (fn [b] (nil? (find-index |(= $ (b 1)) pat-var-set))) ctor-binders)
         eq-binders (ctor/ford-eqs data-params ret-args)
         patterns (map |(pat/from-term $ pat-var-set) ret-args)
         encoded (ctor/ford-encoded data-name data-params pat-binders ctor-params eq-binders)]
@@ -469,7 +448,7 @@
             ctor-binders (ctor/args->binders (slice rhs 1 (length rhs)))]
         (let [ret-term (term/build-data-app data-name selectors)
               ctor-type (term/build-forall ctor-binders ret-term)
-              synthetic [:list @[(node/atom/new ctor-name) ctor-type]]]
+              synthetic [:list @[[ :atom ctor-name ] ctor-type]]]
           (ctor/lower data-name data-params synthetic))))))
 
 (defn data/lower [nodes]
@@ -517,7 +496,7 @@
   (map |($ 1) (slice params 0 end-exclusive)))
 
 (defn node/binder [name ty]
-  [:list @[(node/atom/new (string name ":")) ty]])
+  [:list @[[ :atom (string name ":") ] ty]])
 
 (defn term/build-lam [binders body]
   (if (zero? (length binders))
@@ -526,7 +505,7 @@
           (if (= (length binders) 1)
             (node/binder ((binders 0) 1) ((binders 0) 2))
             [:list (map |(node/binder ($ 1) ($ 2)) binders)])]
-      [:list @[(node/atom/new "fn") spec body]])))
+      [:list @[[ :atom "fn" ] spec body]])))
 
 (defn term/self-call? [node func-name param-names target-index rec-var]
   (let [[head args] (term/as-head-app node)]
@@ -577,12 +556,7 @@
     true (errorf "invalid match target: %v\nMatch target must be a variable or annotated variable like 'x:Type'" node)))
 
 (defn match/param-index [params name]
-  (defn find-param-iter [i params]
-    (when (not (empty? params))
-      (if (= ((first params) 1) name)
-        i
-        (find-param-iter (+ i 1) (slice params 1)))))
-  (find-param-iter 0 params))
+  (find-index |(= ($ 1) name) params))
 
 (defn case/split [case-node]
   (let [xs (node/list-items case-node)]
@@ -614,23 +588,12 @@
        (range 2 (length xs))))
 
 (defn match/wildcard-body [entries]
-  (defn find-wildcard [entries]
-    (when (not (empty? entries))
-      (let [e (first entries)]
-        (if (and (= ((e 0) 0) :pat/var)
-                 (= ((e 0) 1) "_"))
-          (e 1)
-          (find-wildcard (slice entries 1))))))
-  (find-wildcard entries))
+  (when-let [entry (find |(and (= (($ 0) 0) :pat/var)
+                               (= (($ 0) 1) "_")) entries)]
+    (entry 1)))
 
 (defn match/find-ctor-entry [entries ctor-name]
-  (defn find-ctor [entries]
-    (when (not (empty? entries))
-      (let [e (first entries)]
-        (if (ctor/case-args (e 0) ctor-name)
-          e
-          (find-ctor (slice entries 1))))))
-  (find-ctor entries))
+  (find |(ctor/case-args ($ 0) ctor-name) entries))
 
 (def M/Yes :match/yes)
 (def M/No :match/no)
@@ -659,8 +622,8 @@
   [;subst [x term]])
 
 (defn selector/head-ctor? [head ctor-names var-names]
-  (and (seq/contains? ctor-names head)
-       (not (seq/contains? var-names head))))
+  (and (find-index |(= $ head) ctor-names)
+       (nil? (find-index |(= $ head) var-names))))
 
 (defn selector/mismatch [head ctor-names var-names]
   (if (selector/head-ctor? head ctor-names var-names)
@@ -788,7 +751,7 @@
     (cond
       (= tok "impossible") [:pat/impossible]
       (= tok "_") [:pat/var "_"]
-      (and (= depth 0) (seq/contains? ctor-names tok)) [:pat/con tok @[]]
+      (and (= depth 0) (not (nil? (find-index |(= $ tok) ctor-names)))) [:pat/con tok @[]]
       true [:pat/var tok])
 
     [:list xs]
@@ -822,7 +785,7 @@
                       @[]
                       (range consumed))
               wildcard-patterns (map (fn [_] [:pat/var "_"]) (range (- (length params) consumed)))
-              patterns (seq/concat parsed-patterns wildcard-patterns)
+              patterns (tuple/join parsed-patterns wildcard-patterns)
               rest-params (slice params consumed (length params))
               wrapped-body (term/build-lam rest-params body)]
           [:clause patterns wrapped-body]))
@@ -868,7 +831,7 @@
     (walk 0 @[] @[])))
 
 (defn branch/with-obligations [branch-binders obligations]
-  (seq/concat branch-binders obligations))
+  (tuple/join branch-binders obligations))
 
 (defn branch/rewrite-self-calls [body rec-pairs func-name param-names target-index]
   (reduce (fn [acc pair]
@@ -918,9 +881,9 @@
                 wildcard-body (match/wildcard-body entries)
                 motive (term/build-lam @[[ :bind target target-ty ]] result)
                 branches (match/build-branches data-name ctors func-name param-names target-index result entries wildcard-body status-by-ctor)]
-            (let [app (seq/concat
-                       (seq/concat @[(node/atom/new (string data-name "-elim")) motive] branches)
-                       @[[:atom target]])]
+            (let [app (tuple/join @[[ :atom (string data-name "-elim") ] motive]
+                                   branches
+                                   @[[:atom target]])]
               [:list app]))
           (errorf "unknown data type %v in match target %v\nEnsure the data declaration appears before this function" data-name target))))))
 
@@ -976,6 +939,7 @@
   {:lower/program lower/program
    :decl/lower decl/lower
    :record/lower record/lower
+   :bind/single-spec? bind/single-spec?
    :bind/from-node bind/from-node
    :binders/from-spec binders/from-spec
    :term/split-pi term/split-pi

--- a/src/frontend/surface/ast.janet
+++ b/src/frontend/surface/ast.janet
@@ -79,7 +79,7 @@
   (ensure-int>= level 0 "decl/prec.level >= 0")
   [:decl/prec fixity level op sp])
 
-(defn decl/data [name params ctors sp] [:decl/data name params ctors sp])
+(defn decl/data [name params sort ctors sp] [:decl/data name params sort ctors sp])
 (defn decl/func [name ty clauses sp] [:decl/func name ty clauses sp])
 (defn decl/compute [tm sp] [:decl/compute tm sp])
 (defn decl/check [tm ty sp] [:decl/check tm ty sp])

--- a/src/frontend/surface/decls.janet
+++ b/src/frontend/surface/decls.janet
@@ -94,7 +94,9 @@
     (while (and (< i n) (not found))
       (let [c (text i)]
         (cond
-          (= c (chr "(")) (++ depth)
+          (= c (chr "(")) (do
+                           (++ depth)
+                           (++ i))
           (= c (chr ")")) (do
                           (-- depth)
                           (when (= depth 0)
@@ -120,7 +122,7 @@
         (let [trimmed (ly/trim p)]
           (when (not= trimmed "")
             (if (and (string/has-prefix? "(" trimmed) (string/has-suffix? ")" trimmed))
-              (array/push out (parse/field-fragment (string/slice trimmed 1 -2) syntax mk-named mk-anon))
+              (array/push out (parse/field-fragment (string/slice trimmed 1 (- (length trimmed) 1)) syntax mk-named mk-anon))
               (array/push out (parse/field-fragment trimmed syntax mk-named mk-anon))))))
       out)))
 
@@ -137,41 +139,107 @@
 (defn- parse/type-params [text syntax]
   (if (or (nil? text) (= (ly/trim text) ""))
     @[]
-    (let [parts (ly/split-top-level text (chr ","))
+    (let [raw-parts (ly/split-top-level text (chr ","))
+          parts @[]
           out @[]]
+      (var pending nil)
+      (each raw raw-parts
+        (let [part (ly/trim raw)]
+          (when (not= part "")
+            (let [chunk (if pending
+                          (string pending "," part)
+                          part)]
+              (if (ly/find-top-level-char chunk (chr ":"))
+                (do
+                  (array/push parts chunk)
+                  (set pending nil))
+                (set pending chunk))))))
+      (when pending
+        (array/push parts pending))
       (each p parts
         (let [x (ly/trim p)]
           (when (not= x "")
             (if-let [ix (ly/find-top-level-char x (chr ":"))]
-              (array/push out
-                          (a/decl/param (ly/trim (string/slice x 0 ix))
-                                        (pr/parse/type-text (ly/trim (string/slice x (+ ix 1))) syntax)
-                                        (a/span/none)))
+              (let [names-part (ly/trim (string/slice x 0 ix))
+                    ty (pr/parse/type-text (ly/trim (string/slice x (+ ix 1))) syntax)
+                    names (ly/split-top-level names-part (chr ","))]
+                (each name names
+                  (let [trimmed-name (ly/trim name)]
+                    (when (not= trimmed-name "")
+                      (array/push out
+                                  (a/decl/param trimmed-name
+                                                ty
+                                                (a/span/none)))))))
               (array/push out (a/decl/param x nil (a/span/none)))))))
       out)))
 
-(defn- parse/ctor-rhs [rhs syntax]
-  (let [trimmed (ly/trim rhs)]
-    (cond
-      (= trimmed "()") [nil @[]]
+(defn- split-field-segments [text]
+  (let [trimmed (ly/trim text)
+        out @[]
+        n (length trimmed)]
+    (var i 0)
+    (while (< i n)
+      (while (and (< i n) (ly/is-space-byte? (trimmed i)))
+        (++ i))
+      (when (< i n)
+        (if (= (trimmed i) (chr "("))
+          (if-let [end (read-parenthesized-end trimmed i)]
+            (do
+              (array/push out (string/slice trimmed i end))
+              (set i end))
+            (errorf "unclosed constructor field list: %s" trimmed))
+          (let [start i]
+            (while (and (< i n) (not (ly/is-space-byte? (trimmed i))))
+              (++ i))
+            (array/push out (string/slice trimmed start i))))))
+    out))
 
-      (and (string/find "(" trimmed)
-           (string/has-suffix? ")" trimmed))
-      (let [lp (string/find "(" trimmed)
-            name (ly/trim (string/slice trimmed 0 lp))
-            rest (string/slice trimmed (+ lp 1) (- (length trimmed) 1))]
-        [name (parse/fields rest syntax a/decl/field-named a/decl/field-anon)])
+(defn- parse/field-segment [segment syntax mk-named mk-anon]
+  (let [trimmed (ly/trim segment)
+        n (length trimmed)]
+    (if (or (= trimmed "") (= trimmed "()"))
+      @[]
+      (if (and (> n 1)
+               (= (trimmed 0) (chr "("))
+               (= (trimmed (- n 1)) (chr ")")))
+        (parse/fields (string/slice trimmed 1 (- n 1)) syntax mk-named mk-anon)
+        @[(parse/field-fragment trimmed syntax mk-named mk-anon)]))))
+
+(defn- parse/ctor-rhs [rhs syntax]
+  (let [trimmed (ly/trim rhs)
+        n (length trimmed)]
+    (cond
+      (or (= trimmed "()") (= trimmed ""))
+      [nil @[]]
 
       true
-      (let [parts (ly/split-ws-top-level trimmed)]
-        (when (zero? (length parts))
+      (let [name-end (or (ly/find-top-level-char trimmed (chr " "))
+                         (ly/find-top-level-char trimmed (chr "\t"))
+                         (ly/find-top-level-char trimmed (chr "("))
+                         n)
+            name (ly/trim (string/slice trimmed 0 name-end))
+            rest (ly/trim (string/slice trimmed name-end n))
+            segments (ly/split-ws-top-level rest)
+            fields @[]]
+        (when (= name "")
           (error "empty constructor rhs"))
-        (let [name (ly/trim (parts 0))
-              rest (if (> (length parts) 1)
-                     (string/slice trimmed (+ (length (parts 0)) 1))
-                     "")
-              field-text (strip-optional-parens rest)]
-          [name (parse/fields field-text syntax a/decl/field-named a/decl/field-anon)])))))
+        (each segment segments
+          (each field (parse/field-segment segment syntax a/decl/field-named a/decl/field-anon)
+            (array/push fields field)))
+        [name fields]))))
+
+(defn- wrap-type-params [ty params]
+  (reduce (fn [body param]
+            (let [name (param 1)
+                  dom (or (param 2) (a/ty/universe 0 (a/span/none)))]
+              (a/ty/pi (a/ty/binder name dom (a/span/none)) body (a/span/none))))
+          ty
+          (reverse params)))
+
+(defn- resolve-import-path [path]
+  (if (string/has-prefix? "@examples/" path)
+    (string "examples/" (string/slice path (length "@examples/")))
+    path))
 
 (defn- diag/error [ln message]
   (error {:kind :surface/diag
@@ -197,14 +265,72 @@
         [(a/decl/ctor-plain name fields (a/span/none))]
         [])))))
 
-(defn- parse/term-body-line [ln syntax]
+(defn- type/arity [ty]
+  (match ty
+    [:ty/pi _ body _] (+ 1 (type/arity body))
+    [:ty/arrow _ cod _] (+ 1 (type/arity cod))
+    _ 0))
+
+(defn- ctor/arity [ctor]
+  (match ctor
+    [:ctor/plain _ fields _] (length fields)
+    [:ctor/indexed _ _ fields _] (length fields)
+    _ 0))
+
+(defn- ctor-env/add! [env ctor]
+  (match ctor
+    [:ctor/plain name _ _] (put env name (ctor/arity ctor))
+    [:ctor/indexed _ name _ _] (put env name (ctor/arity ctor))
+    _ nil))
+
+(defn- parse/pat-from-parts [parts start ctor-env]
+  (let [part (parts start)
+        trimmed (ly/trim part)
+        n (length trimmed)
+        paren-token? (and (> n 1)
+                          (= (trimmed 0) (chr "("))
+                          (= (trimmed (- n 1)) (chr ")")))]
+    (cond
+      paren-token?
+      [(pat/parse/pat-text trimmed) (+ start 1)]
+
+      (nil? (get ctor-env trimmed))
+      [(pat/parse/pat-text trimmed) (+ start 1)]
+
+      true
+      (let [arity (get ctor-env trimmed)
+            args @[]]
+        (var i 0)
+        (var cur (+ start 1))
+        (while (< i arity)
+          (when (>= cur (length parts))
+            (errorf "constructor pattern %s expects %d argument(s)" trimmed arity))
+          (let [[arg next-cur] (parse/pat-from-parts parts cur ctor-env)]
+            (array/push args arg)
+            (set cur next-cur))
+          (++ i))
+        [(a/pat/con trimmed args (a/span/none)) cur]))))
+
+(defn- parse/clause-patterns [lhs arity ctor-env]
+  (let [parts (ly/split-ws-top-level lhs)
+        pats @[]]
+    (var cur 0)
+    (for _ 0 arity
+      (when (>= cur (length parts))
+        (errorf "expected %d pattern(s), got %d in clause: %s" arity (length pats) lhs))
+      (let [[pat next-cur] (parse/pat-from-parts parts cur ctor-env)]
+        (array/push pats pat)
+        (set cur next-cur)))
+    (when (< cur (length parts))
+      (errorf "too many pattern fragments in clause: %s" lhs))
+    pats))
+
+(defn- parse/term-body-line [ln syntax arity ctor-env]
   (let [text (ln :text)]
     (if-let [eq (peg/match peg/split-eq-line text)]
     (let [lhs (ly/trim (eq 0))
           rhs (ly/trim (eq 1))
-          pats @[]]
-      (each part (ly/split-ws-top-level lhs)
-        (array/push pats (pat/parse/pat-text part)))
+          pats (parse/clause-patterns lhs arity ctor-env)]
       (a/decl/clause pats (pr/parse/expr-text rhs syntax) (a/span/none)))
     (diag/error ln (string "invalid clause line: " text)))))
 
@@ -250,63 +376,58 @@
 (set parse/source
      (fn [src &opt syntax]
        (let [syn (or syntax (sx/syntax/default))
-             lines (ly/indent/tokenize src)
-             decls @[]]
-         (var current nil)
+              lines (ly/indent/tokenize src)
+              decls @[]
+              ctor-env @{}]
+          (var current nil)
 
          (defn flush-current []
            (when current
              (match (current :kind)
-                :data-head
-                (let [params (parse/type-params (current :params-text) syn)
-                       ctors @[]]
-                  (each bl (current :body)
-                    (let [new-ctors (parse/data-body-line bl syn)]
-                     (each c new-ctors (array/push ctors c))))
-                 (array/push decls (a/decl/data (current :name) params ctors (a/span/none))))
+               :data-head
+                 (let [params (parse/type-params (current :params-text) syn)
+                       sort-text (current :sort-text)
+                       body-lines (current :body)
+                       ctors @[]
+                       source-for-ctors (if (and (nil? (next body-lines)) (not (= sort-text "")))
+                                          (let [dummy-line {:text (string (current :name) ": " sort-text) :line 0 :col 0}]
+                                            @[dummy-line])
+                                          body-lines)]
+                    (each bl source-for-ctors
+                      (let [new-ctors (parse/data-body-line bl syn)]
+                        (each c new-ctors (array/push ctors c))))
+                    (let [sort (if (= (ly/trim sort-text) "")
+                                 (a/ty/universe 0 (a/span/none))
+                                 (pr/parse/type-text sort-text syn))
+                          decl (a/decl/data (current :name) params sort ctors (a/span/none))]
+                      (array/push decls decl)
+                      (each ctor ctors
+                        (ctor-env/add! ctor-env ctor))))
 
-               :term-head
-               (let [body-lines (current :body)
-                     type-parts @[]
-                     clause-lines @[]
-                     _ (do
-                          (var found-clause false)
-                          (each bl body-lines
+                :term-head
+                (let [body-lines (current :body)
+                      params (parse/type-params (current :params-text) syn)
+                      type-parts @[]
+                      clause-lines @[]
+                      _ (do
+                           (var found-clause false)
+                           (each bl body-lines
                             (if found-clause
                               (array/push clause-lines bl)
                               (if (peg/match peg/split-eq-line (bl :text))
-                                (do (set found-clause true)
-                                    (array/push clause-lines bl))
-                                (array/push type-parts bl)))))
-                      head-type (or (current :type-text) "")
-                      full-type-text (if (or (zero? (length type-parts)) (= (string/trim (string/join (map |($ :text) type-parts) "")) ""))
-                                      (if (and head-type (not= (string/trim head-type) "")) head-type "?")
-                                      (string head-type " " (string/join (map |($ :text) type-parts) " ")))
-                     params-text (current :params-text)
-                     # Weave params into type as Pi binders
-                     final-type-text
-                     (if (and params-text (not= params-text ""))
-                       (let [param-parts (ly/split-top-level params-text (chr ","))
-                             pi-prefix @[]]
-                         (each pp param-parts
-                           (let [tp (ly/trim pp)]
-                             (when (not= tp "")
-                               (if-let [colon-ix (ly/find-top-level-char tp (chr ":"))]
-                                 (let [names-part (ly/trim (string/slice tp 0 colon-ix))
-                                       ty-part (ly/trim (string/slice tp (+ colon-ix 1)))
-                                       names (ly/split-top-level names-part (chr ","))]
-                                   (each nm names
-                                     (let [n (ly/trim nm)]
-                                       (when (not= n "")
-                                         (array/push pi-prefix (string "Pi(" n ": " ty-part "). "))))))
-                                 (array/push pi-prefix (string "Pi(" tp ": Type). "))))))
-                         (string (string/join pi-prefix "") full-type-text))
-                       full-type-text)
-                      ty (pr/parse/type-text final-type-text syn)
-                      clauses @[]]
-                  (each cl clause-lines
-                    (array/push clauses (parse/term-body-line cl syn)))
-                 (array/push decls (a/decl/func (current :name) ty clauses (a/span/none)))))
+                                 (do (set found-clause true)
+                                     (array/push clause-lines bl))
+                                 (array/push type-parts bl)))))
+                       head-type (or (current :type-text) "")
+                       full-type-text (if (or (zero? (length type-parts)) (= (string/trim (string/join (map |($ :text) type-parts) "")) ""))
+                                       (if (and head-type (not= (string/trim head-type) "")) head-type "?")
+                                       (string head-type " " (string/join (map |($ :text) type-parts) " ")))
+                       ty (wrap-type-params (pr/parse/type-text full-type-text syn) params)
+                       arity (type/arity ty)
+                       clauses @[]]
+                   (each cl clause-lines
+                     (array/push clauses (parse/term-body-line cl syn arity ctor-env)))
+                  (array/push decls (a/decl/func (current :name) ty clauses (a/span/none)))))
              (set current nil)))
 
           (each ln lines
@@ -330,15 +451,16 @@
                          :top/alias
                          (sx/syntax/add-alias! syn (top 1) (top 2))
 
-                         :top/import
-                         (let [path (top 1)
-                               q "\""
-                               path (if (and (string/has-prefix? q path) (string/has-suffix? q path))
-                                      (string/slice path 1 -2)
-                                      path)
-                               ext (if (string/has-suffix? ".requiem" path) "" ".requiem")
-                               full-path (string path ext)
-                               content (if (os/stat full-path) (slurp full-path) nil)]
+                          :top/import
+                          (let [path (top 1)
+                                q "\""
+                                path (if (and (string/has-prefix? q path) (string/has-suffix? q path))
+                                       (string/slice path 1 (- (length path) 1))
+                                       path)
+                                path (resolve-import-path path)
+                                ext (if (string/has-suffix? ".requiem" path) "" ".requiem")
+                                full-path (string path ext)
+                                content (if (os/stat full-path) (slurp full-path) nil)]
                             (if content
                               (let [prog (parse/source (string content) syn)
                                     ds (prog 1)]

--- a/src/frontend/surface/lower.janet
+++ b/src/frontend/surface/lower.janet
@@ -17,9 +17,6 @@
 (defn- node/binder [name ty]
   [:list @[(atom (string name ":")) ty]])
 
-(defn- seq/contains? [xs x]
-  (not (nil? (find-index |(= $ x) xs))))
-
 (defn- assoc/get [pairs key]
   (defn scan [i]
     (if (< i 0)
@@ -30,21 +27,15 @@
           (scan (- i 1))))))
   (scan (- (length pairs) 1)))
 
-(defn- assoc/has? [pairs key]
-  (not (nil? (assoc/get pairs key))))
-
-(defn- seq/concat [xs ys]
-  (reduce (fn [acc y] [;acc y]) xs ys))
-
 (defn- binders/name->type [binders]
   (map |[($ 1) ($ 2)] binders))
 
 (defn- binders/unique-by-name [binders]
   (let [step (fn [[seen out] b]
                (let [name (b 1)]
-                 (if (seq/contains? seen name)
-                   [seen out]
-                   [[;seen name] [;out b]])))
+                  (if (not (nil? (find-index |(= $ name) seen)))
+                    [seen out]
+                    [[;seen name] [;out b]])))
         [_ out] (reduce step [@[] @[]] (reverse binders))]
     (reverse out)))
 
@@ -66,8 +57,8 @@
     (cond
       (and (tuple? node) (= (node 0) :atom))
       (let [tok (node 1)]
-        (if (and (assoc/has? var-types tok)
-                 (not (seq/contains? seen tok)))
+        (if (and (assoc/get var-types tok)
+                 (nil? (find-index |(= $ tok) seen)))
           [[;seen tok] [;out tok]]
           [seen out]))
 
@@ -82,9 +73,9 @@
 (defn- pat/from-term [term pat-var-set]
   (match term
     [:atom tok]
-    (if (seq/contains? pat-var-set tok)
-      [:pat/var tok]
-      [:pat/con tok @[]])
+      (if (not (nil? (find-index |(= $ tok) pat-var-set)))
+        [:pat/var tok]
+        [:pat/con tok @[]])
 
     [:list xs]
     (if (and (> (length xs) 0) (tuple? (xs 0)) (= ((xs 0) 0) :atom))
@@ -110,7 +101,7 @@
 (defn- build-data-app [name args]
   (if (zero? (length args))
     (atom name)
-    (lst (reduce (fn [acc a] [;acc a]) @[(atom name)] args))))
+    (lst (tuple/join @[(atom name)] args))))
 
 (defn- term/build-lam [binders body]
   (if (zero? (length binders))
@@ -207,6 +198,30 @@
       [binders cur]))
   (split-loop node 0 @[]))
 
+(defn- binder/name-hint [ty]
+  (match ty
+    [:ty/name name _sp]
+    (if (> (length name) 0)
+      (string/ascii-lower (string/slice name 0 1))
+      "arg")
+
+    [:ty/var name _sp]
+    name
+
+    [:ty/app f _ _sp]
+    (binder/name-hint f)
+
+    _ "arg"))
+
+(defn- binder/fresh-name [used base index]
+  (let [prefix (if (= base "") "arg" base)
+        candidate (if (and (= index 0) (nil? (find-index |(= $ prefix) used)))
+                    prefix
+                    (string prefix index))]
+    (if (find-index |(= $ candidate) used)
+      (binder/fresh-name used prefix (+ index 1))
+      candidate)))
+
 # ---------------------------------------------------------------
 # Type lowering
 # ---------------------------------------------------------------
@@ -246,9 +261,7 @@
          (if name (atom (string "?" name)) (atom "?"))
 
          [:ty/universe level _sp]
-         (if (zero? level)
-           (atom "Type")
-           (atom (string "U" level)))
+          (atom (string "Type" level))
 
          [:ty/name name _sp]
          (atom name)
@@ -265,11 +278,11 @@
          [:ty/pi binder body _sp]
          (lst @[(atom "forall") (lower/binder binder) (atom ".") (lower/type body)])
 
-         [:ty/sigma binder body _sp]
-         (lst @[(atom "Sigma") (lower/binder binder) (atom ".") (lower/type body)])
+          [:ty/sigma binder body _sp]
+          (lst @[(atom "Sigma") (lower/binder binder) (atom ".") (lower/type body)])
 
-         [:ty/op op args _sp]
-         (lst (reduce (fn [acc arg] [;acc (lower/type arg)]) @[(atom op)] args))
+          [:ty/op op args _sp]
+          (lst (tuple/join @[(atom op)] (map lower/type args)))
 
          _ (errorf "lower/type: unknown node %v" node))))
 
@@ -311,13 +324,13 @@
                    (lower/term body)]))
 
          [:tm/let name value body _sp]
-         (lst @[(atom "let")
-                (atom (string name ":"))
-                (lower/term value)
-                (lower/term body)])
+          (lst @[(atom "let")
+                 (atom (string name ":"))
+                 (lower/term value)
+                 (lower/term body)])
 
-         [:tm/op op args _sp]
-         (lst (reduce (fn [acc arg] [;acc (lower/term arg)]) @[(atom op)] args))
+          [:tm/op op args _sp]
+          (lst (tuple/join @[(atom op)] (map lower/term args)))
 
          _ (errorf "lower/term: unknown node %v" node))))
 
@@ -353,9 +366,7 @@
     [:pat/con name args _sp]
     (if (zero? (length args))
       (atom name)
-      (lst (reduce (fn [acc a] [;acc (lower/pat-to-term a)])
-                   @[(atom name)]
-                   args)))
+      (lst (tuple/join @[(atom name)] (map lower/pat-to-term args))))
     _ (errorf "lower/pat-to-term: unknown pattern %v" pat)))
 
 # ---------------------------------------------------------------
@@ -371,15 +382,20 @@
     _ (errorf "lower/param: unknown param %v" param)))
 
 (defn- lower/ctor-fields-as-binders [fields]
-  (let [out @[]]
+  (let [out @[]
+        used @[]]
     (for i 0 (length fields)
       (let [f (fields i)]
         (match f
           [:field/named name ty _sp]
-          (array/push out [:bind name (lower/type ty)])
+          (do
+            (array/push out [:bind name (lower/type ty)])
+            (array/push used name))
 
           [:field/anon ty _sp]
-          (array/push out [:bind (string "_arg" i) (lower/type ty)])
+          (let [name (binder/fresh-name used (binder/name-hint ty) 0)]
+            (array/push out [:bind name (lower/type ty)])
+            (array/push used name))
 
           _ (errorf "lower/ctor-fields-as-binders: unknown field %v" f))))
     out))
@@ -405,8 +421,8 @@
 (defn- ctor/ford-encoded [data-name data-params pat-binders ctor-params eq-binders]
   (let [data-param-terms (map |(atom ($ 1)) data-params)
         result-term (build-data-app data-name data-param-terms)
-        base-binders (binders/unique-by-name (seq/concat data-params (seq/concat pat-binders ctor-params)))
-        all-binders (seq/concat base-binders eq-binders)]
+        base-binders (binders/unique-by-name (tuple/join data-params pat-binders ctor-params))
+        all-binders (tuple/join base-binders eq-binders)]
     (build-forall all-binders result-term)))
 
 (defn- args/simple-return? [args data-params]
@@ -424,11 +440,11 @@
           (check-index 0))))
 
 (defn- ctor/lower-indexed [data-name data-params name ctor-binders ret-args]
-  (let [var-types (binders/name->type (binders/unique-by-name (seq/concat data-params ctor-binders)))
+  (let [var-types (binders/name->type (binders/unique-by-name (tuple/join data-params ctor-binders)))
         ordered-vars (term/collect-var-order ret-args var-types)
         pat-var-set ordered-vars
         pat-binders (map |[:bind $ (assoc/get var-types $)] ordered-vars)
-        ctor-params (filter |(not (seq/contains? pat-var-set ($ 1))) ctor-binders)
+        ctor-params (filter (fn [b] (nil? (find-index |(= $ (b 1)) pat-var-set))) ctor-binders)
         eq-binders (ctor/ford-eqs data-params ret-args)
         patterns (map |(pat/from-term $ pat-var-set) ret-args)
         encoded (ctor/ford-encoded data-name data-params pat-binders ctor-params eq-binders)]
@@ -530,7 +546,7 @@
                       (match lowered
                         [:pat/var name]
                         (if (and (not= name "_")
-                                 (seq/contains? ctor-names name))
+                                 (not (nil? (find-index |(= $ name) ctor-names))))
                           [;acc [:pat/con name @[]]]
                           [;acc lowered])
                         _ [;acc lowered])))
@@ -539,7 +555,7 @@
           consumed (length lowered-pats)
           wildcard-pats (map (fn [_] [:pat/var "_"])
                              (range (- (length params) consumed)))
-          all-pats (seq/concat lowered-pats wildcard-pats)
+          all-pats (tuple/join lowered-pats wildcard-pats)
           rest-params (slice params consumed (length params))
           lowered-body (lower/term body)
           wrapped-body (term/build-lam rest-params lowered-body)]
@@ -559,9 +575,9 @@
     [:decl/prec fixity level op _sp]
     [:decl/prec fixity level op]
 
-    [:decl/data name params ctors _sp]
+    [:decl/data name params sort ctors _sp]
     (let [lowered-params (map lower/param params)
-          sort (atom "Type")
+          sort (lower/type sort)
           lowered-ctors (map |(ctor/lower name lowered-params $) ctors)]
       [:decl/data name lowered-params sort lowered-ctors])
 

--- a/src/frontend/surface/pratt.janet
+++ b/src/frontend/surface/pratt.janet
@@ -111,8 +111,8 @@
       (when (zero? (length params))
         (errorf "parse error at %s: lambda expects at least one parameter" (tok/at tok)))
       (let [sep (pstate/next st)]
-        (when (and (not= (sep :k) :dot) (not= (sep :k) :fat-arrow))
-          (errorf "parse error at %s: lambda expects '.' or '=>', got %s" (tok/at sep) (tok/render sep))))
+        (when (not= (sep :k) :dot)
+          (errorf "parse error at %s: lambda expects '.', got %s" (tok/at sep) (tok/render sep))))
       (a/tm/lam params (parse/expr st 0) (a/span/none)))
     :kw/let
     (let [name ((pstate/expect st :ident) :v)]

--- a/src/frontend/surface/syntax.janet
+++ b/src/frontend/surface/syntax.janet
@@ -26,13 +26,23 @@
          (for i 1 (length name)
            (when (not (is-digit-byte? (name i)))
              (set ok false)))
-         ok)))
+          ok)))
+
+(defn name/is-type-universe? [name]
+  (and (string/has-prefix? "Type" name)
+       (let [suffix (string/slice name 4)]
+         (or (= suffix "")
+             (do
+               (var ok true)
+               (for i 0 (length suffix)
+                 (when (not (is-digit-byte? (suffix i)))
+                   (set ok false)))
+               ok)))))
 
 (defn syntax/default []
   @{:literals @[
       {:lit "->" :k :op :v "->"}
       {:lit "→" :k :op :v "->"}
-      {:lit "=>" :k :fat-arrow :v :fat-arrow}
       {:lit "\\" :k :lambda :v :lambda}
       {:lit "λ" :k :lambda :v :lambda}
       {:lit "Pi" :k :quant :v :pi}
@@ -48,6 +58,11 @@
       :sigma a/ty/sigma
     }
     :type/ident-resolvers @[
+      (fn [name sp]
+        (if (name/is-type-universe? name)
+          (let [suffix (string/slice name 4)]
+            (a/ty/universe (if (= suffix "") 0 (scan-number suffix)) sp))
+          nil))
       (fn [name sp]
         (if (name/is-universe? name)
           (a/ty/universe (scan-number (string/slice name 1)) sp)
@@ -96,7 +111,11 @@
       "forall" (syntax/add-literal! sx new-lit :quant :pi)
       "sigma" (syntax/add-literal! sx new-lit :quant :sigma)
       "pi" (syntax/add-literal! sx new-lit :quant :pi)
-      (errorf "cannot alias unknown literal or keyword: %v" target-lit)))
+      (if (or (= target-lit "Type")
+              (name/is-type-universe? target-lit)
+              (name/is-universe? target-lit))
+        (syntax/add-literal! sx new-lit :ident target-lit)
+        (errorf "cannot alias unknown literal or keyword: %v" target-lit))))
   sx)
 
 (defn syntax/add-quant-alias! [sx new-lit kind]
@@ -135,6 +154,7 @@
   {:starts-with-at? starts-with-at?
    :name/is-upper? name/is-upper?
    :name/is-universe? name/is-universe?
+   :name/is-type-universe? name/is-type-universe?
    :syntax/default syntax/default
    :syntax/clone syntax/clone
    :syntax/add-literal! syntax/add-literal!

--- a/src/matches.janet
+++ b/src/matches.janet
@@ -61,15 +61,10 @@
     [:napp _ _] true
     [:nfst _] true
     [:nsnd _] true
-    true false))
+     true false))
 
 (defn pat/var? [p] (and (tuple? p) (= (p 0) :pat/var)))
 (defn pat/con? [p] (and (tuple? p) (= (p 0) :pat/con)))
-(defn pat/hole? [p] (and (tuple? p) (= (p 0) :hole)))
-
-(defn pat/var-name [p] (p 1))
-(defn pat/con-name [p] (p 1))
-(defn pat/con-args [p] (p 2))
 
 (defn pat/vars [p]
   (match p
@@ -110,14 +105,14 @@
          (outcome/yes (subst/extend (subst/empty) (p 1) u))
 
          (pat/var? p)
-         (let [x (pat/var-name p)]
+         (let [x (p 1)]
            (if (= x "_")
              (outcome/yes (subst/empty))
              (outcome/yes (subst/extend (subst/empty) x u))))
 
          (pat/con? p)
-         (let [ctor (pat/con-name p)
-               pats (pat/con-args p)
+         (let [ctor (p 1)
+               pats (p 2)
                [head args] (term/head-args u)]
            (cond
              (term/neutral? u) (outcome/stuck)

--- a/src/meta.janet
+++ b/src/meta.janet
@@ -5,9 +5,8 @@
 (defn make [deps]
   (let [goals @[]
         ty/type (deps :ty/type)
-        lower (deps :lower)
         ctx/lookup (deps :ctx/lookup)
-        print/sem (deps :print/sem)]
+        goal-ty (ty/type 100)]
     (var collect? false)
 
     (defn context-vars [Γ]
@@ -15,8 +14,8 @@
 
     (defn report [name expected Γ]
       (let [goal {:name name
-                  :expected (lower (ty/type 100) expected)
-                  :ctx (map (fn [k] [k (lower (ty/type 100) (ctx/lookup Γ k))]) (h/keys Γ))}]
+                  :expected expected
+                  :ctx (map (fn [k] [k (ctx/lookup Γ k)]) (h/keys Γ))}]
         (array/push goals goal)))
 
     (defn set-collect! [enabled]
@@ -26,7 +25,7 @@
     (defn error-infer [name Γ]
       (if collect?
         (do
-          (report name (ty/type 100) Γ)
+          (report name goal-ty Γ)
           [:type 100])
         (errorf "unsolved goal ?%v during inference\nNo expected type is available in inference mode.\nContext variables: %v"
                 name
@@ -37,9 +36,8 @@
         (do
           (report name expected Γ)
           true)
-        (errorf "unsolved goal ?%v during checking\nExpected type: %s\nContext variables: %v"
+        (errorf "unsolved goal ?%v during checking\nContext variables: %v"
                 name
-                (print/sem expected)
                 (context-vars Γ))))
 
     {:goals goals

--- a/src/pretty.janet
+++ b/src/pretty.janet
@@ -2,240 +2,29 @@
 
 (import ./coreTT :as tt)
 (import ./levels :as lvl)
-
-(var state/name-map nil)
-(var state/used-names nil)
-(var state/fresh-id 0)
-
-(defn- state/reset! []
-  (set state/fresh-id 0)
-  (set state/name-map @{})
-  (set state/used-names @{}))
-
-(defn- state/mark-used! [name]
-  (put state/used-names name true)
-  name)
-
-(defn- state/used? [name]
-  (get state/used-names name))
-
-(defn- internal-name? [x]
-  (let [s (string x)]
-    (and (> (length s) 0)
-         (= (s 0) (chr "_")))))
-
-(defn- alpha-name [n]
-  (let [letters "abcdefghijklmnopqrstuvwxyz"]
-    (defn recur [k]
-      (let [q (div k 26)
-            r (% k 26)
-            ch (string/slice letters r (+ r 1))]
-        (if (= q 0)
-          ch
-          (string (recur (- q 1)) ch))))
-    (recur n)))
-
-(defn- fresh-name []
-  (var out nil)
-  (while (nil? out)
-    (let [candidate (alpha-name state/fresh-id)]
-      (++ state/fresh-id)
-      (when (not (state/used? candidate))
-        (set out (state/mark-used! candidate)))))
-  out)
-
-(defn- disambiguate [preferred]
-  (if (not (state/used? preferred))
-    (state/mark-used! preferred)
-    (do
-      (var out nil)
-      (var n 1)
-      (while (nil? out)
-        (let [candidate (string preferred n)]
-          (if (state/used? candidate)
-            (++ n)
-            (set out (state/mark-used! candidate)))))
-      out)))
-
-(defn- name [x]
-  (or (get state/name-map x)
-      (let [preferred (string x)
-            out (if (internal-name? x)
-                  (fresh-name)
-                  (disambiguate preferred))]
-        (put state/name-map x out)
-        out)))
-
-(defn- wrap [s]
-  (string "(" s ")"))
-
-(var print/ne* nil)
-(var print/nf* nil)
-(var print/tm* nil)
-
-(defn- atomic-ne? [ne]
-  (match ne
-    [:nvar _] true
-    _ false))
-
-(defn- atomic-nf? [nf]
-  (let [tag (if (tuple? nf) (get nf 0) nil)]
-    (or (and (= tag tt/NF/Type))
-        (and (= tag tt/NF/Neut)
-             (tuple? (get nf 1))
-             (= ((get nf 1) 0) :nvar)))))
-
-(defn- atomic-tm? [tm]
-  (match tm
-    [:var _] true
-    [:type _] true
-    [:hole _] true
-    _ false))
-
-(defn- level-text [l]
-  (cond
-    (int? l) (string (lvl/value l))
-    (lvl/const? l) (string (lvl/value l))
-    (lvl/shift? l) (string (lvl/value l))
-    (and (tuple? l) (> (length l) 1) (int? (get l 1))) (string (get l 1))
-    true (string/format "%v" l)))
-
-(defn- ne-arg [ne]
-  (let [rendered (print/ne* ne)]
-    (if (atomic-ne? ne) rendered (wrap rendered))))
-
-(defn- nf-arg [nf]
-  (let [rendered (print/nf* nf)]
-    (if (atomic-nf? nf) rendered (wrap rendered))))
-
-(defn- tm-arg [tm]
-  (let [rendered (print/tm* tm)]
-    (if (atomic-tm? tm) rendered (wrap rendered))))
-
-(set print/ne*
-     (fn [ne]
-       (match ne
-         [:nvar x] (name x)
-         [:napp f x] (string (ne-arg f) " " (nf-arg x))
-         [:nfst p] (string "fst " (ne-arg p))
-         [:nsnd p] (string "snd " (ne-arg p))
-         [:nJ A x P d y p]
-         (string "J "
-                 (nf-arg A) " "
-                 (nf-arg x) " "
-                 (nf-arg P) " "
-                 (nf-arg d) " "
-                 (nf-arg y) " "
-                 (ne-arg p))
-         _ (string/format "%v" ne))))
-
-(set print/nf*
-     (fn [nf]
-       (let [tag (if (tuple? nf) (get nf 0) nil)]
-         (cond
-           (= tag tt/NF/Type)
-           (let [l (get nf 1)]
-             (string "Type" (level-text l)))
-
-           (= tag tt/NF/Pi)
-           (let [A (get nf 1)
-                 B (get nf 2)
-                 x (fresh-name)]
-             (string "Pi(" x " : " (print/nf* A) "). " (print/nf* (B x))))
-
-           (= tag tt/NF/Sigma)
-           (let [A (get nf 1)
-                 B (get nf 2)
-                 x (fresh-name)]
-             (string "Sigma(" x " : " (print/nf* A) "). " (print/nf* (B x))))
-
-           (= tag tt/NF/Id)
-           (string "Id " (nf-arg (get nf 1)) " " (nf-arg (get nf 2)) " " (nf-arg (get nf 3)))
-
-           (= tag tt/NF/Refl)
-           (string "refl " (nf-arg (get nf 1)))
-
-           (= tag tt/NF/Pair)
-           (string "(" (print/nf* (get nf 1)) ", " (print/nf* (get nf 2)) ")")
-
-           (= tag tt/NF/Lam)
-           (let [body (get nf 1)
-                 x (fresh-name)]
-             (string "λ" x ". " (print/nf* (body x))))
-
-           (= tag tt/NF/Neut)
-           (print/ne* (get nf 1))
-
-            true (string/format "%v" nf)))))
-
-(set print/tm*
-     (fn [tm]
-       (match tm
-         [:var x] (name x)
-         [:app f x] (string (tm-arg f) " " (tm-arg x))
-         [:type l] (string "Type" l)
-         [:lam body]
-         (let [x (fresh-name)]
-           (string "λ" x ". " (print/tm* (body [:var x]))))
-         [:t-pi A B]
-         (let [x (fresh-name)]
-           (string "Pi(" x " : " (print/tm* A) "). " (print/tm* (B [:var x]))))
-         [:t-sigma A B]
-         (let [x (fresh-name)]
-           (string "Sigma(" x " : " (print/tm* A) "). " (print/tm* (B [:var x]))))
-         [:pair l r] (string "(" (print/tm* l) ", " (print/tm* r) ")")
-         [:fst p] (string "fst " (tm-arg p))
-         [:snd p] (string "snd " (tm-arg p))
-         [:t-id A x y] (string "Id " (tm-arg A) " " (tm-arg x) " " (tm-arg y))
-         [:t-refl x] (string "refl " (tm-arg x))
-         [:t-J A x P d y p]
-         (string "J "
-                 (tm-arg A) " "
-                 (tm-arg x) " "
-                 (tm-arg P) " "
-                 (tm-arg d) " "
-                 (tm-arg y) " "
-                 (tm-arg p))
-         [:hole name]
-         (if name (string "?" name) "?")
-         _ (string/format "%v" tm))))
-
-(defn- with-state [f]
-  (let [saved-id state/fresh-id
-        saved-map state/name-map
-        saved-used state/used-names]
-    (state/reset!)
-    (def out (f))
-    (set state/fresh-id saved-id)
-    (set state/name-map saved-map)
-    (set state/used-names saved-used)
-    out))
-
-(defn print/ne [ne]
-  (with-state (fn [] (print/ne* ne))))
-
-(defn print/nf [nf]
-  (with-state (fn [] (print/nf* nf))))
-
-(defn print/tm [tm]
-  (with-state (fn [] (print/tm* tm))))
-
-(defn print/sem [sem]
-  (with-state
-    (fn []
-      (let [tag (if (tuple? sem) (get sem 0) 0)]
-        (cond
-          (= tag tt/T/Neutral) (print/ne (get sem 1))
-          (= tag tt/T/Type) (print/nf (tt/lower (tt/ty/type 100) sem))
-          (= tag tt/T/Pi) (print/nf (tt/lower (tt/ty/type 100) sem))
-          (= tag tt/T/Sigma) (print/nf (tt/lower (tt/ty/type 100) sem))
-          (= tag tt/T/Id) (print/nf (tt/lower (tt/ty/type 100) sem))
-          (= tag tt/T/Refl) (string "refl " (print/sem (get sem 1)))
-          (= tag tt/T/Pair) (string "(" (print/sem (get sem 1)) ", " (print/sem (get sem 2)) ")")
-          true (string/format "%v" sem))))))
+(import ./print :as printer)
 
 (def exports
-  {:print/tm print/tm
-   :print/nf print/nf
-   :print/ne print/ne
-   :print/sem print/sem})
+  (printer/make {:T/Type tt/T/Type
+                 :T/Pi tt/T/Pi
+                 :T/Sigma tt/T/Sigma
+                 :T/Id tt/T/Id
+                 :T/Refl tt/T/Refl
+                 :T/Neutral tt/T/Neutral
+                 :T/Pair tt/T/Pair
+                 :NF/Neut tt/NF/Neut
+                 :NF/Lam tt/NF/Lam
+                 :NF/Pi tt/NF/Pi
+                 :NF/Sigma tt/NF/Sigma
+                 :NF/Type tt/NF/Type
+                 :NF/Pair tt/NF/Pair
+                 :NF/Id tt/NF/Id
+                 :NF/Refl tt/NF/Refl
+                 :ty/type tt/ty/type
+                 :lower tt/lower
+                 :lvl/value lvl/value}))
+
+(def print/tm (exports :print/tm))
+(def print/nf (exports :print/nf))
+(def print/ne (exports :print/ne))
+(def print/sem (exports :print/sem))

--- a/src/print.janet
+++ b/src/print.janet
@@ -1,0 +1,263 @@
+#!/usr/bin/env janet
+
+(defn make [deps]
+  (let [T/Type (deps :T/Type)
+        T/Pi (deps :T/Pi)
+        T/Sigma (deps :T/Sigma)
+        T/Id (deps :T/Id)
+        T/Refl (deps :T/Refl)
+        T/Neutral (deps :T/Neutral)
+        T/Pair (deps :T/Pair)
+        NF/Neut (deps :NF/Neut)
+        NF/Lam (deps :NF/Lam)
+        NF/Pi (deps :NF/Pi)
+        NF/Sigma (deps :NF/Sigma)
+        NF/Type (deps :NF/Type)
+        NF/Pair (deps :NF/Pair)
+        NF/Id (deps :NF/Id)
+        NF/Refl (deps :NF/Refl)
+        ty/type (deps :ty/type)
+        lower (deps :lower)
+        lvl/value (deps :lvl/value)]
+    (var state/name-map nil)
+    (var state/used-names nil)
+    (var state/fresh-id 0)
+    (var print/ne* nil)
+    (var print/nf* nil)
+    (var print/tm* nil)
+
+    (defn state/reset! []
+      (set state/fresh-id 0)
+      (set state/name-map @{})
+      (set state/used-names @{}))
+
+    (defn state/mark-used! [name]
+      (put state/used-names name true)
+      name)
+
+    (defn state/used? [name]
+      (get state/used-names name))
+
+    (defn internal-name? [x]
+      (let [s (string x)]
+        (and (> (length s) 0)
+             (= (s 0) (chr "_")))))
+
+    (defn alpha-name [n]
+      (let [letters "abcdefghijklmnopqrstuvwxyz"]
+        (defn recur [k]
+          (let [q (div k 26)
+                r (% k 26)
+                ch (string/slice letters r (+ r 1))]
+            (if (= q 0)
+              ch
+              (string (recur (- q 1)) ch))))
+        (recur n)))
+
+    (defn find-name [n build]
+      (let [candidate (build n)]
+        (if (state/used? candidate)
+          (find-name (inc n) build)
+          [n candidate])))
+
+    (defn fresh-name []
+      (let [[n candidate] (find-name state/fresh-id alpha-name)]
+        (set state/fresh-id (inc n))
+        (state/mark-used! candidate)))
+
+    (defn disambiguate [preferred]
+      (if (not (state/used? preferred))
+        (state/mark-used! preferred)
+        (let [[_ candidate] (find-name 1 (fn [n] (string preferred n)))]
+          (state/mark-used! candidate))))
+
+    (defn name [x]
+      (or (get state/name-map x)
+          (let [preferred (string x)
+                out (if (internal-name? x)
+                      (fresh-name)
+                      (disambiguate preferred))]
+            (put state/name-map x out)
+            out)))
+
+    (defn wrap [s]
+      (string "(" s ")"))
+
+    (defn tag-of [x]
+      (if (tuple? x) (get x 0) 0))
+
+    (defn atomic-ne? [ne]
+      (match ne
+        [:nvar _] true
+        _ false))
+
+    (defn atomic-nf? [nf]
+      (match nf
+        [NF/Type _] true
+        [NF/Neut [:nvar _]] true
+        _ false))
+
+    (defn atomic-tm? [tm]
+      (match tm
+        [:var _] true
+        [:type _] true
+        [:hole _] true
+        _ false))
+
+    (defn ne-arg [ne]
+      (let [rendered (print/ne* ne)]
+        (if (atomic-ne? ne) rendered (wrap rendered))))
+
+    (defn nf-arg [nf]
+      (let [rendered (print/nf* nf)]
+        (if (atomic-nf? nf) rendered (wrap rendered))))
+
+    (defn tm-arg [tm]
+      (let [rendered (print/tm* tm)]
+        (if (atomic-tm? tm) rendered (wrap rendered))))
+
+    (set print/ne*
+         (fn [ne]
+           (match ne
+             [:nvar x] (name x)
+             [:napp f x] (string (ne-arg f) " " (nf-arg x))
+             [:nfst p] (string "fst " (ne-arg p))
+             [:nsnd p] (string "snd " (ne-arg p))
+             [:nJ A x P d y p]
+             (string "J "
+                     (nf-arg A) " "
+                     (nf-arg x) " "
+                     (nf-arg P) " "
+                     (nf-arg d) " "
+                     (nf-arg y) " "
+                     (ne-arg p))
+             _ (string/format "%v" ne))))
+
+    (set print/nf*
+         (fn [nf]
+            (match nf
+              [NF/Type l]
+              (string "Type" (lvl/value l))
+
+             [NF/Pi A B]
+             (let [x (fresh-name)]
+               (string "Pi(" x " : " (print/nf* A) "). " (print/nf* (B x))))
+
+             [NF/Sigma A B]
+             (let [x (fresh-name)]
+               (string "Sigma(" x " : " (print/nf* A) "). " (print/nf* (B x))))
+
+             [NF/Id A x y]
+             (string "Id " (nf-arg A) " " (nf-arg x) " " (nf-arg y))
+
+             [NF/Refl x]
+             (string "refl " (nf-arg x))
+
+             [NF/Pair l r]
+             (string "(" (print/nf* l) ", " (print/nf* r) ")")
+
+              [NF/Lam body]
+              (let [x (fresh-name)]
+                (string "λ" x "." (print/nf* (body x))))
+
+             [NF/Neut ne]
+             (print/ne* ne)
+
+             _
+             (string/format "%v" nf))))
+
+    (set print/tm*
+         (fn [tm]
+           (match tm
+             [:var x]
+             (name x)
+
+             [:app f x]
+             (string (tm-arg f) " " (tm-arg x))
+
+             [:type l]
+             (string "Type" l)
+
+              [:lam body]
+              (let [x (fresh-name)]
+                (string "λ" x "." (print/tm* (body [:var x]))))
+
+             [:t-pi A B]
+             (let [x (fresh-name)]
+               (string "Pi(" x " : " (print/tm* A) "). " (print/tm* (B [:var x]))))
+
+             [:t-sigma A B]
+             (let [x (fresh-name)]
+               (string "Sigma(" x " : " (print/tm* A) "). " (print/tm* (B [:var x]))))
+
+             [:pair l r]
+             (string "(" (print/tm* l) ", " (print/tm* r) ")")
+
+             [:fst p]
+             (string "fst " (tm-arg p))
+
+             [:snd p]
+             (string "snd " (tm-arg p))
+
+             [:t-id A x y]
+             (string "Id " (tm-arg A) " " (tm-arg x) " " (tm-arg y))
+
+             [:t-refl x]
+             (string "refl " (tm-arg x))
+
+             [:t-J A x P d y p]
+             (string "J "
+                     (tm-arg A) " "
+                     (tm-arg x) " "
+                     (tm-arg P) " "
+                     (tm-arg d) " "
+                     (tm-arg y) " "
+                     (tm-arg p))
+
+             [:hole name]
+             (if name (string "?" name) "?")
+
+             _
+             (string/format "%v" tm))))
+
+    (defn with-state [f]
+      (let [saved-id state/fresh-id
+            saved-map state/name-map
+            saved-used state/used-names]
+        (state/reset!)
+        (def out (f))
+        (set state/fresh-id saved-id)
+        (set state/name-map saved-map)
+        (set state/used-names saved-used)
+        out))
+
+    (defn print/ne [ne]
+      (with-state (fn [] (print/ne* ne))))
+
+    (defn print/nf [nf]
+      (with-state (fn [] (print/nf* nf))))
+
+    (defn print/tm [tm]
+      (with-state (fn [] (print/tm* tm))))
+
+    (defn sem* [sem]
+      (let [tag (tag-of sem)]
+        (cond
+          (= tag T/Neutral) (print/ne* (get sem 1))
+          (= tag T/Type) (print/nf* (lower (ty/type 100) sem))
+          (= tag T/Pi) (print/nf* (lower (ty/type 100) sem))
+          (= tag T/Sigma) (print/nf* (lower (ty/type 100) sem))
+          (= tag T/Id) (print/nf* (lower (ty/type 100) sem))
+          (= tag T/Refl) (string "refl " (sem* (get sem 1)))
+          (= tag T/Pair) (string "(" (sem* (get sem 1)) ", " (sem* (get sem 2)) ")")
+          true (string/format "%v" sem))))
+
+    (defn print/sem [sem]
+      (with-state (fn [] (sem* sem))))
+
+    {:print/tm print/tm
+     :print/nf print/nf
+     :print/ne print/ne
+     :print/sem print/sem}))
+
+(def exports {:make make})

--- a/src/sig.janet
+++ b/src/sig.janet
@@ -46,12 +46,13 @@
       (errorf "sig/ctor: unknown constructor '%v' in '%v'" ctor-name data-name)))
 
 (defn sig/ctor-name-set [sig]
-  (let [out @{}]
-    (eachp [_ entry] sig
-      (when (= (entry :kind) :data)
-        (each ctor (entry :ctors)
-          (put out (ctor :name) true))))
-    out))
+  (reduce
+    (fn [out entry]
+      (if (= (entry :kind) :data)
+        (reduce (fn [acc ctor] (put acc (ctor :name) true)) out (entry :ctors))
+        out))
+    @{}
+    (values sig)))
 
 (defn vars [delta]
   (map |($ :name) delta))
@@ -62,7 +63,7 @@
           args))
 
 (defn build-lambda [body delta]
-  (reduce (fn [inner _binder]
+  (reduce (fn [inner _]
             (tt/tm/lam (fn [_] inner)))
           body
           (reverse delta)))

--- a/src/unify.janet
+++ b/src/unify.janet
@@ -6,27 +6,40 @@
       (errorf "conflicting solutions for %v" mv))
     (put solved mv value)))
 
+(defn- unify/merge-named! [c solved named name value mv]
+  (if (not (has-key? named name))
+    (put named name value)
+    (let [other (get named name)]
+      (cond
+        (and value other (not= value other))
+        (errorf "named hole ?%v has inconsistent constraints" name)
+
+        (and value (nil? other))
+        (put named name value)
+
+        (and (nil? value) other)
+        (do (put c :solution other)
+            (unify/assign! solved mv other))))))
+
 (defn unify/solve [constraints]
   (let [solved @{}
-        named @{}]
+        named  @{}]
+
     (each c constraints
-      (let [mv (c :mv)
+      (let [mv    (c :mv)
             value (or (c :solution) (c :expected))
-            name (c :name)]
+            name  (c :name)]
         (when value
           (unify/assign! solved mv value)
           (put c :solution value))
         (when name
-          (if (has-key? named name)
-            (let [other (get named name)]
-              (when (and value other (not= value other))
-                (errorf "named hole ?%v has inconsistent constraints" name))
-              (when (and value (nil? other))
-                (put named name value))
-              (when (and (nil? value) other)
-                (put c :solution other)
-                (unify/assign! solved mv other)))
-            (put named name value)))))
+          (unify/merge-named! c solved named name value mv))))
+
+    (each c constraints
+      (when (and (c :name) (nil? (c :solution)))
+        (when-let [v (get named (c :name))]
+          (put c :solution v)
+          (unify/assign! solved (c :mv) v))))
 
     (each c constraints
       (when (and (c :name) (nil? (c :solution)))

--- a/test/Parser/Surface.janet
+++ b/test/Parser/Surface.janet
@@ -63,6 +63,56 @@ id: ∀(A: U0). A -> A
       (= (s/node/tag prog) :program)))
   "Program parse output matches schema tool")
 
+(test/assert
+  (let [prog (s/parse/program "sum(n,m: Nat): Nat\n  n zero = n\n")
+        decls (prog 1)
+        sum (decls 0)
+        ty (sum 2)]
+    (and (= (sum 0) :decl/func)
+         (= (s/node/tag ty) :ty/pi)
+         (= ((ty 1) 1) "n")
+         (= (s/node/tag (ty 2)) :ty/pi)
+         (= (((ty 2) 1) 1) "m")))
+  "Grouped function parameters expand to separate Pi binders")
+
+(test/assert
+  (let [prog (s/parse/program "Vec(A: Type, n: Nat):\n  A, (succ n) = vcons (x: A) (xs: Vec A n)\n")
+        decls (prog 1)
+        vec (decls 0)
+        ctor ((vec 4) 0)]
+    (and (= (ctor 0) :ctor/indexed)
+         (= (ctor 2) "vcons")
+         (= (length (ctor 3)) 2)))
+  "Adjacent parenthesized constructor fields parse separately")
+
+(test/assert
+  (let [prog (s/parse/program "Nat:\n  zero\n  succ Nat\n\nclassify: Nat -> Nat\n  zero = zero\n  succ zero = succ zero\n  succ succ n = succ succ n\n")
+        decls (prog 1)
+        classify (decls 1)
+        clauses (classify 3)
+        c1 ((clauses 1) 1)
+        c2 ((clauses 2) 1)
+        nested (((c2 0) 2) 0)]
+    (and (= (length clauses) 3)
+         (= ((c1 0) 0) :pat/con)
+         (= ((c1 0) 1) "succ")
+         (= ((((c1 0) 2) 0) 1) "zero")
+         (= ((c2 0) 0) :pat/con)
+         (= (nested 0) :pat/con)
+         (= (nested 1) "succ")
+         (= (((nested 2) 0) 1) "n")))
+  "Single-argument nested constructor patterns do not need parens")
+
+(test/assert
+  (let [prog (s/parse/program "Nat: Type3\n  zero\n")
+        decls (prog 1)
+        nat (decls 0)
+        sort (nat 3)]
+    (and (= (nat 0) :decl/data)
+         (= (s/node/tag sort) :ty/universe)
+         (= (sort 1) 3)))
+  "Data headers accept explicit universe levels")
+
 (test/assert-error
   (fn []
     (s/parse/type-text "Forall(A: U0). A"))

--- a/test/Parser/SurfaceLower.janet
+++ b/test/Parser/SurfaceLower.janet
@@ -31,4 +31,21 @@
          (= ((lowered 1) 0) :decl/func)))
   "Full program lowers correctly")
 
+(test/assert
+  (let [prog (s/parse/program "Nat:\n  zero\n  succ Nat\n\nBool:\n  true\n  false\n\nisZero: Nat -> Nat -> Bool\n  zero m = true\n  (succ k) m = false\n")
+        lowered (s/lower/program prog)
+        isZero (lowered 2)
+        clauses (isZero 4)
+        c0 (clauses 0)
+        c1 (clauses 1)]
+    (and (= (isZero 0) :decl/func)
+         (= (isZero 1) "isZero")
+         (= (length clauses) 2)
+         (= (((c0 1) 0) 0) :pat/con)
+         (= (((c0 1) 0) 1) "zero")
+         (= (((c1 1) 0) 0) :pat/con)
+         (= (((c1 1) 0) 1) "succ")
+         (= (((((c1 1) 0) 2) 0) 1) "k")))
+  "Current selector-style syntax lowers first-parameter constructor clauses")
+
 (test/end-suite)

--- a/test/Properties/TeslaEncoding.janet
+++ b/test/Properties/TeslaEncoding.janet
@@ -93,8 +93,8 @@
       (test/assert (not (p/has/atom? body "sum")) "structural branch removes direct recursive call"))))
 
 (let [src (string
-            "(data Nat: Type ((zero Nat) (succ (forall (k: Nat). Nat))))"
-            " (data Bool: Type ((true Bool) (false Bool)))"
+             "(data Nat: Type ((zero Nat) (succ (forall (k: Nat). Nat))))"
+             " (data Bool: Type ((true Bool) (false Bool)))"
             " (def sum: (forall (n: Nat). (forall (m: Nat). Nat))"
             "   (| n zero = n)"
             "   (| n (succ m') = (succ (sum n m'))))"
@@ -110,12 +110,12 @@
       not-core (core/find-func core "not")]
   (test/assert (= (length (lowered/clauses sum-decl)) 2) "selector-style sum keeps two clauses")
   (test/assert (= (length (lowered/clauses not-decl)) 2) "selector-style not keeps two clauses")
-  (test/assert (= (length (sum-core 5)) 2) "sum elaborates two clauses")
-  (test/assert (= (length (not-core 5)) 2) "not elaborates two clauses"))
+       (test/assert (= (length (sum-core 5)) 2) "sum elaborates two clauses")
+       (test/assert (= (length (not-core 5)) 2) "not elaborates two clauses"))
 
 (let [src (string
-            "(data Vec (A: Type) (n: Nat): Type "
-            "  (| A zero = vnil)"
+             "(data Vec (A: Type) (n: Nat): Type "
+             "  (| A zero = vnil)"
             "  (| A (succ n) = vcons (x: A) (xs: (Vec A n))))")
       forms (p/parse/text src)
       lowered (l/lower/program forms)

--- a/test/Utils/SurfaceSchema.janet
+++ b/test/Utils/SurfaceSchema.janet
@@ -168,7 +168,7 @@
        (sc/tagged :decl/prec @[(sc/lit :infixr) nonneg-int (sc/string) schema/span])
        (sc/tagged :decl/prec @[(sc/lit :prefix) nonneg-int (sc/string) schema/span])
        (sc/tagged :decl/prec @[(sc/lit :postfix) nonneg-int (sc/string) schema/span])
-       (sc/tagged :decl/data @[(sc/string) (sc/array schema/param) (sc/array schema/ctor) schema/span])
+       (sc/tagged :decl/data @[(sc/string) (sc/array schema/param) schema/type (sc/array schema/ctor) schema/span])
        (sc/tagged :decl/func @[(sc/string) (sc/lazy (fn [] schema/type)) (sc/array schema/clause) schema/span])]))
 
 (def schema/program


### PR DESCRIPTION
## Summary
- improve the `requiem` CLI with direct modes, canonical declaration rendering, Prelude autoloading, and a standalone wrapper command
- tighten the surface language around grouped params, explicit universes, canonical lambda syntax, and `@examples/*` resolution while expanding parser coverage
- make hole and goal reporting much more useful by showing Agda-style local context, available names, preserved binder names, and surfaced type holes

## Verification
- `jpm build`
- `janet test/Parser/Surface.janet`
- `requiem @examples/test.requiem`
- `requiem check /tmp/requiem-goal-local3-dot.requiem`
- `requiem check /tmp/requiem-hole-types.requiem`