### PR TITLE
fix J elaboration and neutral application handling

### DIFF
--- a/native/hamt.c
+++ b/native/hamt.c
@@ -9,6 +9,7 @@
 
 #define BITS 5
 #define MASK ((1 << BITS) - 1)
+#define MAX_DEPTH 12
 
 static inline uint64_t h_hash(const char *key) {
     uint64_t h = 0xcbf29ce484222325ULL;
@@ -17,7 +18,7 @@ static inline uint64_t h_hash(const char *key) {
 }
 
 static inline int h_pop(uint32_t x) { return __builtin_popcount(x); }
-static inline uint32_t h_frag(uint64_t h, int d) { return (h >> ((d * BITS) % 60)) & MASK; }
+static inline uint32_t h_frag(uint64_t h, int d) { return (h >> (d * BITS)) & MASK; }
 
 /* Pointer tagging: LSB 1 = Leaf, 0 = Node */
 #define T_LEAF  1
@@ -25,7 +26,13 @@ static inline uint32_t h_frag(uint64_t h, int d) { return (h >> ((d * BITS) % 60
 static inline bool is_leaf(void *p) { return ((uintptr_t)p & T_LEAF) != 0; }
 static inline void *get_ptr(void *p) { return (void *)((uintptr_t)p & ~T_LEAF); }
 
-/* Arena allocator */
+/* Arena allocator
+ *
+ * Chunks are bump-allocated and never compacted in place. Memory usage is
+ * therefore proportional to the number of persistent nodes retained across
+ * updates until the owning HAMT becomes unreachable and arena_dec frees the
+ * whole arena.
+ */
 #define ARENA_CHUNK (64 * 1024)
 
 typedef struct Chunk { struct Chunk *next; } Chunk;
@@ -65,11 +72,16 @@ static char *arena_strdup(Arena *a, const char *s) {
 
 /* Node structures */
 typedef struct { uint32_t bits; void *kids[]; } Node;
-typedef struct { uint64_t hash; char *key; Janet val; } Leaf;
+typedef struct Leaf {
+    uint64_t hash;
+    char *key;
+    Janet val;
+    struct Leaf *next;
+} Leaf;
 
-static Leaf *leaf_new(Arena *a, const char *k, Janet v, uint64_t h) {
+static Leaf *leaf_new(Arena *a, const char *k, Janet v, uint64_t h, Leaf *next) {
     Leaf *l = arena_alloc(a, sizeof(Leaf));
-    l->key = arena_strdup(a, k); l->val = v; l->hash = h;
+    l->key = arena_strdup(a, k); l->val = v; l->hash = h; l->next = next;
     return l;
 }
 
@@ -80,17 +92,31 @@ static Node *node_new(Arena *a, uint32_t bits, int count) {
 }
 
 static inline void *mk_leaf(Arena *a, const char *k, Janet v, uint64_t h) {
-    return (void *)((uintptr_t)leaf_new(a, k, v, h) | T_LEAF);
+    return (void *)((uintptr_t)leaf_new(a, k, v, h, NULL) | T_LEAF);
+}
+
+static Leaf *leaf_put(Arena *a, Leaf *old, const char *k, Janet v, uint64_t h, bool *added) {
+    if (!old) {
+        *added = true;
+        return leaf_new(a, k, v, h, NULL);
+    }
+    if (old->hash == h && !strcmp(old->key, k)) {
+        *added = false;
+        return leaf_new(a, k, v, h, old->next);
+    }
+    Leaf *next = leaf_put(a, old->next, k, v, h, added);
+    return leaf_new(a, old->key, old->val, old->hash, next);
 }
 
 /* Core operations - now using pre-computed hash */
 static int h_get(void *n, const char *k, uint64_t h, int d, Janet *out) {
     if (!n) return 0;
     if (is_leaf(n)) {
-        Leaf *l = get_ptr(n);
-        if (l->hash == h && !strcmp(l->key, k)) { *out = l->val; return 1; }
+        for (Leaf *l = get_ptr(n); l; l = l->next)
+            if (l->hash == h && !strcmp(l->key, k)) { *out = l->val; return 1; }
         return 0;
     }
+    if (d >= MAX_DEPTH) return 0;
     Node *node = n; uint32_t idx = h_frag(h, d);
     if (!(node->bits & (1u << idx))) return 0;
     int pos = (node->bits == 0xFFFFFFFF) ? idx : h_pop(node->bits & ((1u << idx) - 1));
@@ -102,7 +128,9 @@ static void *h_put(Arena *a, void *n, const char *k, Janet v, uint64_t h, int d,
     
     if (is_leaf(n)) {
         Leaf *ol = get_ptr(n);
-        if (ol->hash == h && !strcmp(ol->key, k)) { *added = false; return mk_leaf(a, k, v, h); }
+        if (ol->next || ol->hash == h || d >= MAX_DEPTH) {
+            return (void *)((uintptr_t)leaf_put(a, ol, k, v, h, added) | T_LEAF);
+        }
         
         *added = true;
         char *lk = ol->key; Janet lv = ol->val;
@@ -123,6 +151,9 @@ static void *h_put(Arena *a, void *n, const char *k, Janet v, uint64_t h, int d,
     }
     
     Node *node = n;
+    if (d >= MAX_DEPTH) {
+        janet_panic("hamt: unreachable node beyond MAX_DEPTH");
+    }
     uint32_t idx = h_frag(h, d), bit = 1u << idx;
     int pos = h_pop(node->bits & (bit - 1)), count = h_pop(node->bits);
     
@@ -144,10 +175,11 @@ static void *h_put(Arena *a, void *n, const char *k, Janet v, uint64_t h, int d,
 static void h_collect(void *n, JanetTable *t, JanetArray *keys) {
     if (!n) return;
     if (is_leaf(n)) {
-        Leaf *l = get_ptr(n);
-        Janet k = janet_wrap_string(janet_cstring(l->key));
-        if (t) janet_table_put(t, k, l->val);
-        if (keys) janet_array_push(keys, k);
+        for (Leaf *l = get_ptr(n); l; l = l->next) {
+            Janet k = janet_wrap_string(janet_cstring(l->key));
+            if (t) janet_table_put(t, k, l->val);
+            if (keys) janet_array_push(keys, k);
+        }
         return;
     }
     Node *node = n; int c = h_pop(node->bits);

--- a/src/checker.janet
+++ b/src/checker.janet
@@ -8,6 +8,7 @@
         T/Pair (deps :T/Pair)
         T/Neutral (deps :T/Neutral)
         ty/type (deps :ty/type)
+        ty/pi (deps :ty/pi)
         eq-type (deps :eq-type)
         ty/id (deps :ty/id)
         lvl/<= (deps :lvl/<=)
@@ -15,9 +16,11 @@
         lvl/succ (deps :lvl/succ)
         sem-eq (deps :sem-eq)
         eval (deps :eval)
+        lower (deps :lower)
         raise (deps :raise)
         ctx/add (deps :ctx/add)
         ctx/lookup (deps :ctx/lookup)
+        ne/app (deps :ne/app)
         ne/var (deps :ne/var)
         ne/fst (deps :ne/fst)
         print/sem (deps :print/sem)
@@ -40,15 +43,15 @@
 
     (defn subtype/pi [A1 B1 A2 B2]
       (and (subtype A2 A1)
-           (with-fresh-sem A2
-             (fn [_ arg-sem]
-               (subtype (B1 arg-sem) (B2 arg-sem))))))
+            (with-fresh-sem A2
+              (fn [_fresh arg-sem]
+                (subtype (B1 arg-sem) (B2 arg-sem))))))
 
     (defn subtype/sigma [A1 B1 A2 B2]
       (and (subtype A1 A2)
-           (with-fresh-sem A1
-             (fn [_ arg-sem]
-               (subtype (B1 arg-sem) (B2 arg-sem))))))
+            (with-fresh-sem A1
+              (fn [_fresh arg-sem]
+                (subtype (B1 arg-sem) (B2 arg-sem))))))
 
     (defn tag-of [x]
       (if (tuple? x) (get x 0) 0))
@@ -63,6 +66,35 @@
           (= tag T/Neutral) (sem/neutral (ne/fst (get p-sem 1)))
           true (errorf "fst expected pair semantics, got: %s" (print/sem p-sem)))))
 
+    (defn j/motive-app-term [P y p]
+      (if (function? P)
+        (P y p)
+        [:app [:app P y] p]))
+
+    (defn sem/apply [f-ty f-sem arg-sem]
+      (let [tag (tag-of f-ty)]
+        (if (= tag T/Pi)
+          (let [[_tag A B] f-ty
+                B-sem (B arg-sem)
+                ftag (tag-of f-sem)]
+            {:ty B-sem
+             :sem (cond
+                    (= ftag T/Neutral)
+                    (raise B-sem (ne/app (get f-sem 1) (lower A arg-sem)))
+
+                    (function? f-sem)
+                    (f-sem arg-sem)
+
+                    true
+                    (errorf "expected function semantics for application, got: %v" f-sem))})
+          (errorf "expected Pi type for semantic application, got: %s"
+                  (print/sem f-ty)))))
+
+    (defn j/motive-app-typed [P-ty P-sem yv pv]
+      (let [step1 (sem/apply P-ty P-sem yv)
+            step2 (sem/apply (step1 :ty) (step1 :sem) pv)]
+        (step2 :sem)))
+
     (set subtype
          (fn [A B]
             "Semantic subtyping with cumulative universes and Pi/Sigma variance."
@@ -73,13 +105,13 @@
                 (lvl/<= (get A 1) (get B 1))
 
                (and (= tagA T/Pi) (= tagB T/Pi))
-               (let [[_ A1 B1] A
-                     [_ A2 B2] B]
+               (let [[_tag1 A1 B1] A
+                      [_tag2 A2 B2] B]
                  (subtype/pi A1 B1 A2 B2))
 
                (and (= tagA T/Sigma) (= tagB T/Sigma))
-               (let [[_ A1 B1] A
-                     [_ A2 B2] B]
+               (let [[_tag1 A1 B1] A
+                      [_tag2 A2 B2] B]
                  (subtype/sigma A1 B1 A2 B2))
 
                 true
@@ -98,141 +130,177 @@
       (let [lvlA (check-univ Γ A)
             A-sem (eval Γ A)
             lvlB (with-bound Γ A-sem
-                   (fn [fresh _ Γ2]
+                   (fn [fresh _arg-sem Γ2]
                      (check-univ Γ2 (B [:var fresh]))))]
         (ty/type (lvl/max lvlA lvlB))))
 
     (set infer
          (fn [Γ t]
            "Infer the type of term t in context Γ (returns semantic type)"
-           (match t
-             [:var x]
-             (if (or (string? x) (symbol? x))
-               (ctx/lookup Γ x)
-               (errorf "variable must be a string or symbol, but got: %v\nVariable names should be like 'x', 'y', 'myVar', etc." x))
+           (let [tag (if (tuple? t) (get t 0) nil)]
+             (cond
+               (= tag :var)
+               (let [x (get t 1)]
+                 (if (or (string? x) (symbol? x))
+                   (ctx/lookup Γ x)
+                   (errorf "variable must be a string or symbol, but got: %v\nVariable names should be like 'x', 'y', 'myVar', etc." x)))
 
-             [:type l] (ty/type (lvl/succ l))
+               (= tag :type)
+               (ty/type (lvl/succ (get t 1)))
 
-             [:lam _]
-             (errorf "cannot infer type of lambda expression %s\nLambda types require annotation because they have principal types.\nSuggestion: Annotate with a Pi type: (λx. body) : (Πx:A. B)"
-                     (print/tm t))
+               (= tag :lam)
+               (errorf "cannot infer type of lambda expression %s\nLambda types require annotation because they have principal types.\nSuggestion: Annotate with a Pi type: (λx. body) : (Πx:A. B)"
+                       (print/tm t))
 
-             [:hole name]
-              ((meta :error-infer) name Γ)
+               (= tag :hole)
+               ((meta :error-infer) (get t 1) Γ)
 
-              [:app f x]
-              (let [fA (infer Γ f)
-                    tag (tag-of fA)]
-                (if (= tag T/Pi)
-                  (let [[_ A B] fA]
-                    (do (check Γ x A)
-                       (B (eval Γ x))))
-                 (errorf "cannot apply function - expected a Pi type (Πx:A. B), but got: %s\nTip: Make sure the function has a proper Pi type annotation or can be inferred as one."
-                          (print/sem fA))))
+               (= tag :app)
+               (let [f (get t 1)
+                     x (get t 2)
+                     fA (infer Γ f)
+                     ftag (tag-of fA)]
+                 (if (= ftag T/Pi)
+                   (let [[_tag A B] fA]
+                     (do (check Γ x A)
+                         (B (eval Γ x))))
+                   (errorf "cannot apply function - expected a Pi type (Πx:A. B), but got: %s\nTip: Make sure the function has a proper Pi type annotation or can be inferred as one."
+                           (print/sem fA))))
 
-              [:t-pi A B]
-              (infer-binder Γ A B)
+               (= tag :t-pi)
+               (infer-binder Γ (get t 1) (get t 2))
 
-              [:t-sigma A B]
-              (infer-binder Γ A B)
+               (= tag :t-sigma)
+               (infer-binder Γ (get t 1) (get t 2))
 
-              [:fst p]
-              (let [pA (infer Γ p)
-                    tag (tag-of pA)]
-                (if (= tag T/Sigma)
-                  (get pA 1)
-                  (errorf "fst projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
-                         (print/sem pA))))
+               (= tag :fst)
+               (let [p (get t 1)
+                     pA (infer Γ p)
+                     ptag (tag-of pA)]
+                 (if (= ptag T/Sigma)
+                   (get pA 1)
+                   (errorf "fst projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
+                           (print/sem pA))))
 
-              [:snd p]
-              (let [pA (infer Γ p)
-                    tag (tag-of pA)]
-                (if (= tag T/Sigma)
-                  (let [[_ _ B] pA
-                        p-sem (eval Γ p)]
-                    (B (fst-sem p-sem)))
-                  (errorf "snd projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
-                          (print/sem pA))))
+               (= tag :snd)
+               (let [p (get t 1)
+                     pA (infer Γ p)
+                     ptag (tag-of pA)]
+                 (if (= ptag T/Sigma)
+                   (let [[_tag _fst B] pA
+                         p-sem (eval Γ p)]
+                     (B (fst-sem p-sem)))
+                   (errorf "snd projection requires a Σ (Sigma) type product, but got: %s\nExpected format: Σx:A. B or a term that evaluates to a Sigma type"
+                           (print/sem pA))))
 
-             [:pair _ _]
-             (errorf "cannot infer type of pair %s\nPairs require explicit Sigma type annotation because they lack principal types.\nSuggestion: (pair a b) : (Σx:A. B)"
-                     (print/tm t))
+               (= tag :pair)
+               (errorf "cannot infer type of pair %s\nPairs require explicit Sigma type annotation because they lack principal types.\nSuggestion: (pair a b) : (Σx:A. B)"
+                       (print/tm t))
 
-              [:t-id A x y]
-              (let [A-ty (infer Γ A)
-                    A-sem (eval Γ A)
-                    tag (tag-of A-ty)]
-                (if (= tag T/Type)
-                  (do (check Γ x A-sem)
-                      (check Γ y A-sem)
-                     (ty/type (get A-ty 1)))
-                 (errorf "Identity type (Id A x y) expects 'A' to be a universe Type, but got: %s\nThe first argument must evaluate to a Type, e.g., Type 0, Type 1, etc."
-                         (print/sem A-ty))))
+               (= tag :t-id)
+               (let [A (get t 1)
+                     x (get t 2)
+                     y (get t 3)
+                     A-ty (infer Γ A)
+                     A-sem (eval Γ A)
+                     A-tag (tag-of A-ty)]
+                 (if (= A-tag T/Type)
+                   (do (check Γ x A-sem)
+                       (check Γ y A-sem)
+                       (ty/type (get A-ty 1)))
+                   (errorf "Identity type (Id A x y) expects 'A' to be a universe Type, but got: %s\nThe first argument must evaluate to a Type, e.g., Type 0, Type 1, etc."
+                           (print/sem A-ty))))
 
-             [:t-refl x]
-             (let [A (infer Γ x)
-                   xv (eval Γ x)]
-               (ty/id A xv xv))
+               (= tag :t-refl)
+               (let [x (get t 1)
+                     A (infer Γ x)
+                     xv (eval Γ x)]
+                 (ty/id A xv xv))
 
-              [:t-J A x P d y p]
-              (let [A-sem (eval Γ A)
-                    P-sem (eval Γ P)]
-                (check-univ Γ A)
-                (check Γ x A-sem)
-                (let [fresh-y (gensym)
-                      fresh-p (gensym)
-                      xv (eval Γ x)
-                      yv-sem (raise A-sem (ne/var fresh-y))
-                      Γ-y (ctx/add Γ fresh-y A-sem)
-                      id-ty (ty/id A-sem xv yv-sem)
-                      Γ-yp (ctx/add Γ-y fresh-p id-ty)]
-                  (check-univ Γ-yp (P [:var fresh-y] [:var fresh-p]))
-                  (let [P-refl (eval Γ (P-sem xv [T/Refl xv]))]
-                    (check Γ d P-refl))
-                  (check Γ y A-sem)
-                  (let [yv (eval Γ y)]
-                    (check Γ p (ty/id A-sem xv yv))
-                    (let [pv (eval Γ p)]
-                      (eval Γ (P-sem yv pv))))))
+               (= tag :t-J)
+               (let [A (get t 1)
+                     x (get t 2)
+                     P (get t 3)
+                     d (get t 4)
+                     y (get t 5)
+                     p (get t 6)
+                     A-sem (eval Γ A)]
+                 (check-univ Γ A)
+                 (check Γ x A-sem)
+                 (let [fresh-y (gensym)
+                       fresh-p (gensym)
+                       xv (eval Γ x)
+                       yv-sem (raise A-sem (ne/var fresh-y))
+                       Γ-y (ctx/add Γ fresh-y A-sem)
+                       id-ty (ty/id A-sem xv yv-sem)
+                       pv-sem (raise id-ty (ne/var fresh-p))
+                       Γ-yp (ctx/add Γ-y fresh-p id-ty)
+                       motive-ty (ty/pi A-sem
+                                        (fn [yv]
+                                          (ty/pi (ty/id A-sem xv yv)
+                                                 (fn [_pv] eq-type))))]
+                    (if (function? P)
+                     (do
+                        (check-univ Γ-yp (j/motive-app-term P [:var fresh-y] [:var fresh-p]))
+                        (let [P-refl (eval Γ (j/motive-app-term P x [:t-refl x]))]
+                          (check Γ d P-refl))
+                        (check Γ y A-sem)
+                        (let [yv (eval Γ y)]
+                          (check Γ p (ty/id A-sem xv yv))
+                          (eval Γ (j/motive-app-term P y p))))
+                      (do
+                        (check Γ P motive-ty)
+                        (let [P-sem (eval Γ P)]
+                         (let [P-refl (j/motive-app-typed motive-ty P-sem xv [T/Refl xv])]
+                           (check Γ d P-refl))
+                         (check Γ y A-sem)
+                         (let [yv (eval Γ y)]
+                           (check Γ p (ty/id A-sem xv yv))
+                           (let [pv (eval Γ p)]
+                             (j/motive-app-typed motive-ty P-sem yv pv))))))))
 
-             _
-             (errorf "infer: unknown term %s\nThis term is not recognized by the type checker.\nSupported forms: var, type, lambda, application, pi, sigma, pair, fst, snd, id, refl, J"
-                     (print/tm t)))))
+               true
+               (errorf "infer: unknown term %s\nThis term is not recognized by the type checker.\nSupported forms: var, type, lambda, application, pi, sigma, pair, fst, snd, id, refl, J"
+                       (print/tm t))))))
 
     (set check
          (fn [Γ t A]
-           (match t
-             [:hole name]
-             ((meta :error-check) name A Γ)
+           (let [tag (if (tuple? t) (get t 0) nil)]
+             (cond
+               (= tag :hole)
+               ((meta :error-check) (get t 1) A Γ)
 
-              [:lam body]
-              (let [tag (tag-of A)]
-                (if (= tag T/Pi)
-                  (let [[_ dom cod] A]
-                    (with-bound Γ dom
-                      (fn [fresh arg-sem Γ2]
-                        (check Γ2
-                               (body [:var fresh])
-                               (cod arg-sem)))))
-                  (errorf "lambda checking failed - expected a Pi type (Πx:A. B), but got: %s\nLambda expressions can only be checked against function types."
-                          (print/sem A))))
+               (= tag :lam)
+               (let [A-tag (tag-of A)
+                     body (get t 1)]
+                 (if (= A-tag T/Pi)
+                   (let [[_tag dom cod] A]
+                     (with-bound Γ dom
+                       (fn [fresh arg-sem Γ2]
+                         (check Γ2
+                                (body [:var fresh])
+                                (cod arg-sem)))))
+                   (errorf "lambda checking failed - expected a Pi type (Πx:A. B), but got: %s\nLambda expressions can only be checked against function types."
+                           (print/sem A))))
 
-              [:pair l r]
-              (let [tag (tag-of A)]
-                (if (= tag T/Sigma)
-                  (let [[_ A1 B1] A]
-                    (do (check Γ l A1)
-                       (check Γ r (B1 (eval Γ l)))))
-                 (errorf "pair checking failed - expected a Sigma type (Σx:A. B), but got: %s\nPair expressions can only be checked against Sigma product types."
-                         (print/sem A))))
+               (= tag :pair)
+               (let [A-tag (tag-of A)
+                     l (get t 1)
+                     r (get t 2)]
+                 (if (= A-tag T/Sigma)
+                   (let [[_tag A1 B1] A]
+                     (do (check Γ l A1)
+                         (check Γ r (B1 (eval Γ l)))))
+                   (errorf "pair checking failed - expected a Sigma type (Σx:A. B), but got: %s\nPair expressions can only be checked against Sigma product types."
+                           (print/sem A))))
 
-             _
-             (let [A1 (infer Γ t)]
-               (if (subtype A1 A)
-                 true
-                 (errorf "type mismatch between expected type and inferred type\nExpected: %s\nInferred: %s\nSuggestion: Check if the terms are actually equal or if there's a type annotation issue."
-                         (print/sem A)
-                         (print/sem A1)))))))
+               true
+               (let [A1 (infer Γ t)]
+                 (if (subtype A1 A)
+                   true
+                   (errorf "type mismatch between expected type and inferred type\nExpected: %s\nInferred: %s\nSuggestion: Check if the terms are actually equal or if there's a type annotation issue."
+                           (print/sem A)
+                           (print/sem A1))))))))
 
     {:infer infer
      :check check

--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -90,6 +90,7 @@
 # NbE: raise / lower
 (var raise nil)
 (var lower nil)
+(var infer nil)
 
 (defn- tag-of [x]
   (if (tuple? x) (get x 0) 0))
@@ -339,10 +340,16 @@
 
 (defn- eval/app [Γ f x]
   (let [fv (eval Γ f)
-        xv (eval Γ x)
-        tag (tag-of fv)]
+         xv (eval Γ x)
+         tag (tag-of fv)]
       (if (= tag T/Neutral)
-        (sem/neutral (ne/app (get fv 1) (lower T/Type0 xv)))
+        (let [fA (infer Γ f)
+              ftag (tag-of fA)]
+          (if (= ftag T/Pi)
+            (let [[_ A _] fA]
+              (sem/neutral (ne/app (get fv 1) (lower A xv))))
+            (errorf "cannot apply neutral term with non-function type: %s"
+                    (print/sem fA))))
         (fv xv))))
 
 (defn- eval/t-pi [Γ A B]
@@ -449,6 +456,7 @@
                  :T/Pair T/Pair
                  :T/Neutral T/Neutral
                  :ty/type ty/type
+                 :ty/pi ty/pi
                  :eq-type T/Type100
                  :ty/id ty/id
                  :lvl/<= lvl/<=
@@ -456,9 +464,11 @@
                  :lvl/succ lvl/succ
                  :sem-eq sem-eq
                  :eval eval
+                 :lower lower
                  :raise raise
                  :ctx/add ctx/add
                  :ctx/lookup ctx/lookup
+                 :ne/app ne/app
                  :ne/var ne/var
                  :ne/fst ne/fst
                  :print/sem print/sem
@@ -468,7 +478,7 @@
 (def goals (meta-state :goals))
 (def goals/set-collect! (meta-state :set-collect!))
 (def goals/collect? (meta-state :collect?))
-(def infer (checker-state :infer))
+(set infer (checker-state :infer))
 (def check (checker-state :check))
 (def subtype (checker-state :subtype))
 

--- a/src/elab.janet
+++ b/src/elab.janet
@@ -120,11 +120,14 @@
 
 (defn elab/function-ref [name params]
   (let [n (length params)]
-    (defn build [i args]
+    (defn build [i mk-app]
       (if (= i n)
-        (term/app-chain [:var name] args)
-        [:lam (fn [x] (build (+ i 1) [;args x]))]))
-    (build 0 @[])))
+        (mk-app [:var name])
+        [:lam (fn [x]
+                (build (+ i 1)
+                       (fn [head]
+                         (mk-app [:app head x]))))]))
+    (build 0 (fn [head] head))))
 
 (defn elab/atom [env sig-env tok exact-ref?]
   (if-let [bound (env/lookup env tok)]

--- a/src/frontend/sexpr/parser.janet
+++ b/src/frontend/sexpr/parser.janet
@@ -131,20 +131,16 @@
 (defn- layout/block->record-forms [block]
   (let [root {:indent -1 :text nil :children @[]}
         lines (string/split "\n" (string block))]
-    (defn walk [rest stack]
-      (if (zero? (length rest))
-        nil
-        (let [line (first rest)]
-          (if (line/ignored? line)
-            (walk (slice rest 1) stack)
-            (let [indent (line/indent line)
-                  text (string/trim line)
-                  node {:indent indent :text text :children @[]}
-                  trimmed (stack/trim stack indent)
-                  parent (trimmed (- (length trimmed) 1))]
-              (array/push (get parent :children) node)
-              (walk (slice rest 1) [;trimmed node]))))))
-    (walk lines @[root])
+    (var stack @[root])
+    (each line lines
+      (when (not (line/ignored? line))
+        (let [indent (line/indent line)
+              text (string/trim line)
+              node {:indent indent :text text :children @[]}
+              trimmed (stack/trim stack indent)
+              parent (trimmed (- (length trimmed) 1))]
+          (array/push (get parent :children) node)
+          (set stack [;trimmed node]))))
     (map (fn [top]
            [:list (reduce (fn [acc child]
                             [;acc (layout/node->entry-form child)])
@@ -210,20 +206,16 @@
 (defn- layout/block->canonical [block]
   (let [root {:indent -1 :text nil :children @[]}
         lines (string/split "\n" (string block))]
-    (defn walk [rest stack]
-      (if (zero? (length rest))
-        nil
-        (let [line (first rest)]
-          (if (line/ignored? line)
-            (walk (slice rest 1) stack)
-            (let [indent (line/indent line)
-                  text (string/trim line)
-                  node {:indent indent :text text :children @[]}
-                  trimmed (stack/trim stack indent)
-                  parent (trimmed (- (length trimmed) 1))]
-              (array/push (get parent :children) node)
-              (walk (slice rest 1) [;trimmed node]))))))
-    (walk lines @[root])
+    (var stack @[root])
+    (each line lines
+      (when (not (line/ignored? line))
+        (let [indent (line/indent line)
+              text (string/trim line)
+              node {:indent indent :text text :children @[]}
+              trimmed (stack/trim stack indent)
+              parent (trimmed (- (length trimmed) 1))]
+          (array/push (get parent :children) node)
+          (set stack [;trimmed node]))))
     (let [tops (get root :children)]
       (when (zero? (length tops))
         (errorf "invalid layout block: %q" block))

--- a/src/sig.janet
+++ b/src/sig.janet
@@ -66,15 +66,15 @@
       (errorf "sig/delta-ref: '%v' is not a function" name))
     (let [delta (e :params)
           n (length delta)]
-      (defn build [i args]
+      (defn build [i mk-app]
         (if (= i n)
-          (reduce (fn [acc arg] (tt/tm/app acc arg))
-                  (tt/tm/var name)
-                  args)
+          (mk-app (tt/tm/var name))
           (tt/tm/lam
            (fn [x]
-             (build (+ i 1) (array/push (array/slice args) x))))))
-      (build 0 @[]))))
+             (build (+ i 1)
+                    (fn [head]
+                      (mk-app (tt/tm/app head x))))))))
+      (build 0 (fn [head] head)))))
 
 (defn sig/available-ctors [sig data-name type-args]
   (let [ctors (sig/ctors sig data-name)

--- a/test/Core/Conversion.janet
+++ b/test/Core/Conversion.janet
@@ -6,7 +6,7 @@
 
 # Test 3: Eta-Equality for Functions
 # λx. f x ≡ f (when x not free in f)
-(let [id-ty (c/tm/pi [:type 0] (fn [x] [:type 0]))
+(let [id-ty (c/ty/pi (c/ty/type 0) (fn [_] (c/ty/type 0)))
       f [:var "f"]
       eta-expanded [:lam (fn [x] [:app f x])]
       Γ (c/ctx/add (c/ctx/empty) "f" id-ty)]
@@ -16,7 +16,7 @@
 
 # Test 4: Eta-Equality for Pairs
 # (fst p, snd p) ≡ p
-(let [pair-ty (c/tm/sigma [:type 0] (fn [x] [:type 0]))
+(let [pair-ty (c/ty/sigma (c/ty/type 0) (fn [_] (c/ty/type 0)))
       p [:var "p"]
       eta-expanded [:pair [:fst p] [:snd p]]
       Γ (c/ctx/add (c/ctx/empty) "p" pair-ty)]

--- a/test/Core/Evaluation.janet
+++ b/test/Core/Evaluation.janet
@@ -55,4 +55,15 @@
     (= (c/eval Γ1 [:var fresh]) [c/T/Neutral [:nvar fresh]])
     "Symbol variables (gensyms) evaluate to neutrals"))
 
+(let [dom (c/ty/pi (c/ty/type 0) (fn [_] (c/ty/type 0)))
+      Γ (c/ctx/add (c/ctx/empty) "f" (c/ty/pi dom (fn [_] (c/ty/type 0))))
+      sem (c/eval Γ [:app [:var "f"] [:lam (fn [x] [:var x])]])
+      ne (get sem 1)
+      arg (get ne 2)]
+  (test/assert suite
+    (and (= (get sem 0) c/T/Neutral)
+         (= (get ne 0) :napp)
+         (= (get arg 0) c/NF/Lam))
+    "Neutral applications keep the lowered argument shape"))
+
 (test/end-suite suite)

--- a/test/Elab/Elab.janet
+++ b/test/Elab/Elab.janet
@@ -4,6 +4,7 @@
 (import ../../src/sig :as s)
 (import ../../src/elab :as e)
 (import ../../src/coreTT :as tt)
+(import ../../src/frontend/sexpr/parser :as p)
 
 (defn mk-sig []
   (let [sig (s/sig/empty)]
@@ -126,5 +127,13 @@
         result ((program 0) 3)]
     (= (result 0) :t-sigma))
   "Dispatch aliases normalize sigma spellings")
+
+(test/assert suite
+  (let [node (p/parse/one "(J Type1 Type0 (fn (y) (fn (p) (Id Type1 Type0 y))) (refl Type0) Type0 (refl Type0))")
+        term ((e/exports :term/elab) @[] node)
+        inferred (tt/infer-top term)]
+    (and (= (term 0) :t-J)
+         (= (get inferred 0) tt/T/Id)))
+  "Elaborated J motives typecheck end-to-end")
 
 (test/end-suite suite)

--- a/test/Elab/Sig.janet
+++ b/test/Elab/Sig.janet
@@ -36,21 +36,21 @@
                     ])
     sig))
 
-(test/start-suite "Elab Signature")
+(def suite (test/start-suite "Elab Signature"))
 
-(test/assert
+(test/assert suite
   (let [names (s/sig/ctor-name-set (mk-nat-sig))]
     (and (has-key? names "zero")
          (has-key? names "succ")))
   "Constructor name set contains all constructors")
 
-(test/assert
+(test/assert suite
   (let [sig (mk-nat-sig)
         available (s/sig/available-ctors sig "Nat" @[])]
     (= (length available) 2))
   "Unindexed constructors are available")
 
-(test/assert
+(test/assert suite
   (let [sig (mk-vec-sig)
         available (s/sig/available-ctors sig
                                          "Vec"
@@ -60,7 +60,7 @@
            (= (ctor :name) "vnil"))))
   "Indexed constructor filtering uses matches")
 
-(test/assert
+(test/assert suite
   (let [sig (mk-nat-sig)]
     (do
       (s/sig/add-func sig
@@ -70,14 +70,14 @@
                       [:t-pi [:var "Nat"] (fn [_] [:var "Nat"])] )
       (let [ref (s/sig/delta-ref sig "id")]
         (and (= (ref 0) :lam)
-             (= ((ref 1) [:var "z"])
-                [:app [:var "id"] [:var "z"]])))))
+              (= ((ref 1) [:var "z"])
+                 [:app [:var "id"] [:var "z"]])))))
   "Exact-ref eta-expands bare function names")
 
-(test/assert-error
+(test/assert-error suite
   (fn []
     (let [sig (mk-nat-sig)]
       (s/sig/delta-ref sig "Nat")))
   "Exact-ref rejects non-function names")
 
-(test/end-suite)
+(test/end-suite suite)


### PR DESCRIPTION
## Summary
- fix the J checker so elaborated curried motives and manually constructed motives both typecheck and evaluate correctly
- preserve domain type information in neutral applications and align tests to use semantic context types
- harden HAMT deep-collision handling, remove quadratic exact-ref building, and add regression coverage for elaboration, evaluation, and suite handling