### PR TITLE
fix semantic equality edge cases and add symbolic universe levels

### DIFF
--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -38,6 +38,7 @@
 
 (def T/Type0 [T/Type 0])
 (def T/Type100 (ty/type 100))
+(def T/TypeOmega T/Type100)
 
 # Term constructors
 (defn tm/var [x] [:var x])
@@ -91,9 +92,22 @@
 (var raise nil)
 (var lower nil)
 (var infer nil)
+(var eval nil)
+(var sem-eq nil)
 
 (defn- tag-of [x]
   (if (tuple? x) (get x 0) 0))
+
+(defn- sem/value? [x]
+  (let [tag (tag-of x)]
+    (or (function? x)
+        (= tag T/Type)
+        (= tag T/Pi)
+        (= tag T/Sigma)
+        (= tag T/Id)
+        (= tag T/Refl)
+        (= tag T/Neutral)
+        (= tag T/Pair))))
 
 (defn- sem/neutral [ne]
   [T/Neutral ne])
@@ -105,6 +119,70 @@
   (let [fresh (gensym)
         arg-sem (named-neutral A fresh)]
     (f fresh arg-sem)))
+
+(defn- sem/apply [f-ty f-sem arg-sem]
+  (let [tag (tag-of f-ty)]
+    (if (= tag T/Pi)
+      (let [[_ A B] f-ty
+            stag (tag-of f-sem)]
+        (cond
+          (= stag T/Neutral) (raise (B arg-sem) (ne/app (get f-sem 1) (lower A arg-sem)))
+          (function? f-sem) (f-sem arg-sem)
+          true (errorf "expected function semantics, got: %v" f-sem)))
+      (errorf "expected Pi type for semantic application, got: %v" f-ty))))
+
+(defn- j-motive-type [A x]
+  (ty/pi A (fn [y] (ty/pi (ty/id A x y) (fn [_] T/Type100)))))
+
+(defn- sem/normalize [x]
+  (if (sem/value? x) x (eval (ctx/empty) x)))
+
+(defn- j-motive-store [P]
+  (if (function? P)
+    [:motive/hoas P]
+    [:motive/sem P]))
+
+(defn- j-motive-result-raw [A x P y p]
+  (match P
+    [:motive/hoas f] (f y p)
+    [:motive/sem f]
+    (let [P-ty (j-motive-type A x)
+          Py-ty ((get P-ty 2) y)
+          Py (sem/apply P-ty f y)
+          result (sem/apply Py-ty Py p)]
+      result)
+    _ (errorf "unknown stored J motive: %v" P)))
+
+(defn- j-motive-result [A x P y p]
+  (sem/normalize (j-motive-result-raw A x P y p)))
+
+(defn- j-motive-result-eq [A x P1 P2 y p]
+  (sem-eq T/TypeOmega
+          (j-motive-result A x P1 y p)
+          (j-motive-result A x P2 y p)))
+
+(defn- j-motive-eq [A x P1 P2]
+  (with-fresh-neutral A
+    (fn [_ y-sem]
+      (let [id-ty (ty/id A x y-sem)]
+        (with-fresh-neutral id-ty
+          (fn [_ p-sem]
+            (j-motive-result-eq A x P1 P2 y-sem p-sem)))))))
+
+(defn- ne-eq/J [ne1 ne2]
+  (let [[_ A1 x1 P1 d1 y1 p1] ne1
+        [_ A2 x2 P2 d2 y2 p2] ne2
+        refl1 [T/Refl x1]
+        refl2 [T/Refl x2]
+        dA1 (j-motive-result A1 x1 P1 x1 refl1)
+        dA2 (j-motive-result A2 x2 P2 x2 refl2)]
+    (and (sem-eq T/TypeOmega A1 A2)
+         (sem-eq A1 x1 x2)
+         (j-motive-eq A1 x1 P1 P2)
+         (sem-eq T/TypeOmega dA1 dA2)
+         (sem-eq dA1 d1 d2)
+         (sem-eq A1 y1 y2)
+         (sem-eq (ty/id A1 x1 y1) p1 p2))))
 
 (defn- raise/pi [A B ne]
   (fn [x]
@@ -218,8 +296,67 @@
 (def print/nf (pp :print/nf))
 (def print/tm (pp :print/tm))
 
+# Structural equality for NbE artifacts
+(var nf-eq nil)
+(var ne-eq nil)
+
+(set nf-eq
+     (fn [v1 v2]
+       (cond
+         (= v1 v2) true
+         (not (and (tuple? v1) (tuple? v2))) (= v1 v2)
+         (not= (get v1 0) (get v2 0)) false
+         (= (get v1 0) NF/Neut) (ne-eq (get v1 1) (get v2 1))
+         (= (get v1 0) NF/Type) (= (get v1 1) (get v2 1))
+         (= (get v1 0) NF/Lam)
+         (let [fresh (gensym)
+               b1 (get v1 1)
+               b2 (get v2 1)]
+           (nf-eq (b1 fresh) (b2 fresh)))
+         (= (get v1 0) NF/Pi)
+         (let [fresh (gensym)
+               a1 (get v1 1)
+               a2 (get v2 1)
+               b1 (get v1 2)
+               b2 (get v2 2)]
+           (and (nf-eq a1 a2)
+                (nf-eq (b1 fresh) (b2 fresh))))
+         (= (get v1 0) NF/Sigma)
+         (let [fresh (gensym)
+               a1 (get v1 1)
+               a2 (get v2 1)
+               b1 (get v1 2)
+               b2 (get v2 2)]
+           (and (nf-eq a1 a2)
+                (nf-eq (b1 fresh) (b2 fresh))))
+         (= (get v1 0) NF/Pair)
+         (and (nf-eq (get v1 1) (get v2 1))
+              (nf-eq (get v1 2) (get v2 2)))
+         (= (get v1 0) NF/Id)
+         (and (nf-eq (get v1 1) (get v2 1))
+              (nf-eq (get v1 2) (get v2 2))
+              (nf-eq (get v1 3) (get v2 3)))
+         (= (get v1 0) NF/Refl)
+         (nf-eq (get v1 1) (get v2 1))
+         true false)))
+
+(set ne-eq
+     (fn [ne1 ne2]
+       (cond
+         (= ne1 ne2) true
+         (not (and (tuple? ne1) (tuple? ne2))) (= ne1 ne2)
+         (not= (get ne1 0) (get ne2 0)) false
+         (= (get ne1 0) :nvar) (= (get ne1 1) (get ne2 1))
+         (= (get ne1 0) :napp)
+         (and (ne-eq (get ne1 1) (get ne2 1))
+              (nf-eq (get ne1 2) (get ne2 2)))
+         (or (= (get ne1 0) :nfst) (= (get ne1 0) :nsnd))
+         (ne-eq (get ne1 1) (get ne2 1))
+         (= (get ne1 0) :nJ)
+         (ne-eq/J ne1 ne2)
+         true (= ne1 ne2))))
+
 # Definitional equality
-(var sem-eq nil)
 
 (defn- sem-eq/type [ty v1 v2]
   (let [t1 (tag-of v1)
@@ -246,6 +383,9 @@
       (let [[_ A1 x1 y1] v1 [_ A2 x2 y2] v2]
         (and (sem-eq ty A1 A2) (sem-eq A1 x1 x2) (sem-eq A1 y1 y2)))
 
+      (and (= t1 T/Neutral) (= t2 T/Neutral))
+      (ne-eq (get v1 1) (get v2 1))
+
       true (= v1 v2))))
 
 (defn- sem-eq/pi [A B v1 v2]
@@ -253,7 +393,11 @@
         t2 (tag-of v2)]
     (cond
       (and (= t1 T/Neutral) (= t2 T/Neutral))
-      (= (get v1 1) (get v2 1))
+      (with-fresh-neutral A
+        (fn [_ arg-sem]
+          (sem-eq (B arg-sem)
+                  (raise (B arg-sem) (ne/app (get v1 1) (lower A arg-sem)))
+                  (raise (B arg-sem) (ne/app (get v2 1) (lower A arg-sem))))))
 
       (= t1 T/Neutral)
       (with-fresh-neutral A
@@ -279,13 +423,20 @@
         t2 (tag-of v2)]
     (cond
       (and (= t1 T/Neutral) (= t2 T/Neutral))
-      (= (get v1 1) (get v2 1))
+      (let [ne1 (get v1 1)
+            ne2 (get v2 1)
+            p1-fst (sem/neutral (ne/fst ne1))
+            p2-fst (sem/neutral (ne/fst ne2))
+            p1-snd (sem/neutral (ne/snd ne1))
+            p2-snd (sem/neutral (ne/snd ne2))]
+        (and (sem-eq A p1-fst p2-fst)
+             (sem-eq (B p1-fst) p1-snd p2-snd)))
 
       (= t1 T/Neutral)
       (let [[_ l2 r2] v2
-            ne1 (get v1 1)
-            p1-fst (sem/neutral (ne/fst ne1))
-            p1-snd (sem/neutral (ne/snd ne1))]
+             ne1 (get v1 1)
+             p1-fst (sem/neutral (ne/fst ne1))
+             p1-snd (sem/neutral (ne/snd ne1))]
         (and (sem-eq A p1-fst l2)
              (sem-eq (B p1-fst) p1-snd r2)))
 
@@ -310,7 +461,7 @@
       (sem-eq A (get v1 1) (get v2 1))
 
       (and (= t1 T/Neutral) (= t2 T/Neutral))
-      (= (get v1 1) (get v2 1))
+      (ne-eq (get v1 1) (get v2 1))
 
       true false)))
 
@@ -326,9 +477,6 @@
              (= tag T/Sigma) (let [[_ A B] ty] (sem-eq/sigma A B v1 v2))
              (= tag T/Id) (let [[_ A _ _] ty] (sem-eq/id A v1 v2))
              true false)))))
-
-# Evaluator
-(var eval nil)
 
 (defn- eval/var [Γ x]
   (if (or (string? x) (symbol? x))
@@ -389,7 +537,7 @@
   (let [pv (eval Γ p)
         Av (eval Γ A)
         xv (eval Γ x)
-        Pv (eval Γ P)
+        Pv (j-motive-store (eval Γ P))
         dv (eval Γ d)
         yv (eval Γ y)
         tag (tag-of pv)]
@@ -407,27 +555,23 @@
 
 (set eval
      (fn [Γ tm]
-       "Evaluate a term in context Γ to a semantic value"
-       (match tm
-         [:Type l] [T/Type l]
-         [:Pi A B] [T/Pi A B]
-         [:Sigma A B] [T/Sigma A B]
-         [:Id A x y] [T/Id A x y]
-         [:refl x] [T/Refl x]
-         [:neutral ne] [T/Neutral ne]
-         [:var x] (eval/var Γ x)
-         [:lam body] (eval/lam Γ body)
-         [:app f x] (eval/app Γ f x)
-         [:type l] (ty/type l)
-         [:t-pi A B] (eval/t-pi Γ A B)
-         [:t-sigma A B] (eval/t-sigma Γ A B)
-         [:pair a b] (eval/pair Γ a b)
-         [:fst p] (eval/fst Γ p)
-         [:snd p] (eval/snd Γ p)
-         [:t-id A x y] (eval/t-id Γ A x y)
-         [:t-refl x] (eval/t-refl Γ x)
-         [:t-J A x P d y p] (eval/t-J Γ A x P d y p)
-         _ (if (function? tm) tm tm))))
+        "Evaluate a term in context Γ to a semantic value"
+        (if (sem/value? tm)
+          tm
+          (match tm
+            [:var x] (eval/var Γ x)
+            [:lam body] (eval/lam Γ body)
+            [:app f x] (eval/app Γ f x)
+            [:type l] (ty/type l)
+            [:t-pi A B] (eval/t-pi Γ A B)
+            [:t-sigma A B] (eval/t-sigma Γ A B)
+            [:pair a b] (eval/pair Γ a b)
+            [:fst p] (eval/fst Γ p)
+            [:snd p] (eval/snd Γ p)
+            [:t-id A x y] (eval/t-id Γ A x y)
+            [:t-refl x] (eval/t-refl Γ x)
+            [:t-J A x P d y p] (eval/t-J Γ A x P d y p)
+            _ tm))))
 
 (defn eval/session [f]
   "Run a computation in a fresh evaluation session with deep stack"

--- a/src/elab.janet
+++ b/src/elab.janet
@@ -168,11 +168,16 @@
   (term/app-chain (elab/callee env sig-env (xs 0))
                   (map |(elab/term env sig-env $) (slice xs 1))))
 
+(defn param/name [param]
+  (if (string? param)
+    param
+    (param 1)))
+
 (defn elab/lam-chain [env sig-env params body]
   (if (zero? (length params))
     (elab/term env sig-env body)
     (let [b (params 0)
-          name (b 1)
+          name (param/name b)
           rest (slice params 1)]
       [:lam (fn [x] (elab/lam-chain (env/extend env name x) sig-env rest body))])))
 

--- a/src/frontend/sexpr/lower.janet
+++ b/src/frontend/sexpr/lower.janet
@@ -453,8 +453,7 @@
 
 (defn data/lower [nodes]
   (let [[name params sort consumed] (data/parse-head nodes)
-        tail-raw (slice nodes consumed (length nodes))
-        tail (if (tuple? tail-raw) (array ;tail-raw) tail-raw)]
+        tail (array ;(slice nodes consumed (length nodes)))]
     (if (zero? (length tail))
       [:decl/data name params sort @[]]
       (if (clause/pipe? (tail 0))

--- a/test/Core/Conversion.janet
+++ b/test/Core/Conversion.janet
@@ -40,4 +40,23 @@
     (c/sem-eq ty f1 f2)
     "Semantic equality: extensional function equality"))
 
+(let [id-ty (c/ty/pi (c/ty/type 0) (fn [_] (c/ty/type 0)))
+      fn-ctx-ty (c/ty/pi id-ty (fn [_] id-ty))
+      Γ (c/ctx/add (c/ctx/empty) "f" fn-ctx-ty)
+      t1 [:app [:var "f"] [:lam (fn [x] [:var x])]]
+      t2 [:app [:var "f"] [:lam (fn [y] [:var y])]]]
+  (test/assert suite
+    (c/term-eq Γ id-ty t1 t2)
+    "Semantic equality: neutral functions compare eta-extensionally"))
+
+(let [id-ty (c/ty/pi (c/ty/type 0) (fn [_] (c/ty/type 0)))
+      sigma-ty (c/ty/sigma id-ty (fn [_] id-ty))
+      pair-ctx-ty (c/ty/pi id-ty (fn [_] sigma-ty))
+      Γ (c/ctx/add (c/ctx/empty) "p" pair-ctx-ty)
+      t1 [:app [:var "p"] [:lam (fn [x] [:var x])]]
+      t2 [:app [:var "p"] [:lam (fn [y] [:var y])]]]
+  (test/assert suite
+    (c/term-eq Γ sigma-ty t1 t2)
+    "Semantic equality: neutral pairs compare by projections"))
+
 (test/end-suite suite)

--- a/test/Core/Evaluation.janet
+++ b/test/Core/Evaluation.janet
@@ -10,6 +10,11 @@
   (= (c/eval (c/ctx/empty) [:type 0]) (c/ty/type 0))
   "eval returns semantic universe [:Type 0], not [:nType 0]")
 
+(let [sem (c/ty/pair (c/ty/type 0) (c/ty/type 1))]
+  (test/assert suite
+    (= (c/eval (c/ctx/empty) sem) sem)
+    "eval preserves semantic values without dead keyword arms"))
+
 (test/assert suite
   (function? (c/eval (c/ctx/empty) [:lam (fn [x] [:var x])]))
   "eval returns Janet function for lambda")

--- a/test/Elab/Elab.janet
+++ b/test/Elab/Elab.janet
@@ -136,4 +136,13 @@
          (= (get inferred 0) tt/T/Id)))
   "Elaborated J motives typecheck end-to-end")
 
+(test/assert suite
+  (let [node [:tm/lam @["x"] [:tm/var "x" nil] nil]
+        term ((e/exports :term/elab) @[] node)
+        body (get term 1)
+        fresh "fresh-x"]
+    (and (= (term 0) :lam)
+         (= (body fresh) fresh)))
+  "Direct surface lambdas accept string params")
+
 (test/end-suite suite)

--- a/test/Parser/Surface.janet
+++ b/test/Parser/Surface.janet
@@ -115,13 +115,19 @@ id: ∀(A: U0). A -> A
 
 (test/assert suite
   (let [prog (s/parse/program "Nat: Type3\n  zero\n")
-        decls (prog 1)
-        nat (decls 0)
-        sort (nat 3)]
+         decls (prog 1)
+         nat (decls 0)
+         sort (nat 3)]
     (and (= (nat 0) :decl/data)
          (= (s/node/tag sort) :ty/universe)
          (= (sort 1) 3)))
   "Data headers accept explicit universe levels")
+
+(test/assert suite
+  (let [prog (s/parse/program "Nat: Type3\n  zero\n")
+        checked (schema/check/program prog)]
+    (= (checked 0) :ok))
+  "Surface schema accepts data declarations with explicit sort")
 
 (test/assert-error suite
   (fn []

--- a/test/Types/J.janet
+++ b/test/Types/J.janet
@@ -32,6 +32,67 @@
 
 (test-transport)
 
+# Test: Neutral J equality with HOAS motives
+(let [Γ (c/ctx/empty)
+      A [:type 1]
+      x [:type 0]
+      A-sem (c/eval Γ A)
+      x-sem (c/eval Γ x)
+      Γy (c/ctx/add Γ "y" A-sem)
+      y [:var "y"]
+      y-sem (c/eval Γy y)
+      id-xy (c/ty/id A-sem x-sem y-sem)
+      Γyp (c/ctx/add Γy "p" id-xy)
+      p [:var "p"]
+      motive1 (fn [z _p] [:t-id A z x])
+      motive2 (fn [w _p] [:t-id A w x])
+      base [:t-refl x]
+      j1 [:t-J A x motive1 base y p]
+      j2 [:t-J A x motive2 base y p]]
+  (test/assert suite
+    (c/term-eq Γyp (c/ty/id A-sem y-sem x-sem) j1 j2)
+    "Neutral J equality compares HOAS motives extensionally"))
+
+(let [Γ (c/ctx/empty)
+      A [:type 1]
+      x [:type 0]
+      A-sem (c/eval Γ A)
+      x-sem (c/eval Γ x)
+      Γy (c/ctx/add Γ "y" A-sem)
+      y [:var "y"]
+      y-sem (c/eval Γy y)
+      id-xy (c/ty/id A-sem x-sem y-sem)
+      Γyp (c/ctx/add Γy "p" id-xy)
+      p [:var "p"]
+      motive1 (fn [_ _p] [:t-pi [:type 0] (fn [_] [:type 0])])
+      motive2 (fn [_ _p] [:t-pi [:type 0] (fn [_] [:type 0])])
+      base1 [:lam (fn [a] [:var a])]
+      base2 [:lam (fn [b] [:var b])]
+      j1 [:t-J A x motive1 base1 y p]
+      j2 [:t-J A x motive2 base2 y p]]
+  (test/assert suite
+    (c/term-eq Γyp (c/ty/pi (c/ty/type 0) (fn [_] (c/ty/type 0))) j1 j2)
+    "Neutral J equality compares HOAS base cases extensionally"))
+
+(let [Γ (c/ctx/empty)
+      A [:type 1]
+      x [:type 0]
+      A-sem (c/eval Γ A)
+      x-sem (c/eval Γ x)
+      Γy (c/ctx/add Γ "y" A-sem)
+      y [:var "y"]
+      y-sem (c/eval Γy y)
+      id-xy (c/ty/id A-sem x-sem y-sem)
+      Γyp (c/ctx/add Γy "p" id-xy)
+      p [:var "p"]
+      motive1 (fn [_ _p] [:type 1])
+      motive2 (fn [_ _p] [:type 2])
+      j1 [:t-J A x motive1 [:type 0] y p]
+      j2 [:t-J A x motive2 [:type 1] y p]]
+  (test/assert suite
+    (not (c/sem-eq (c/ty/type 100) (c/eval Γyp j1) (c/eval Γyp j2)))
+    "Neutral J equality rejects distinct motives"))
+
 # Test: Symmetry (full derivation)
 (defn test-symmetry-derivation []
   "Derive sym : ∀A x y. Id A x y → Id A y x using J"

--- a/test/Utils/SurfaceSchema.janet
+++ b/test/Utils/SurfaceSchema.janet
@@ -14,6 +14,11 @@
 (defn- ok [v] [:ok v])
 (defn- err [m] [:err m])
 
+(var schema/type nil)
+(var schema/term nil)
+(var schema/pat nil)
+(var schema/decl nil)
+
 (defn- path->str [path]
   (if (zero? (length path)) "<root>" (string/join path ".")))
 
@@ -105,11 +110,6 @@
 (def hole-name
   (sc/optional (sc/string)))
 
-(var schema/type nil)
-(var schema/term nil)
-(var schema/pat nil)
-(var schema/decl nil)
-
 (def schema/pos (sc/tagged :pos @[pos-int pos-int nonneg-int]))
 (def schema/span (sc/tagged :span @[schema/pos schema/pos]))
 (def schema/binder (sc/tagged :binder @[(sc/string) (sc/lazy (fn [] schema/type)) schema/span]))
@@ -153,14 +153,13 @@
   (sc/union @[(sc/tagged :ctor/plain @[(sc/string) (sc/array schema/field) schema/span])
               (sc/tagged :ctor/indexed @[(sc/array (sc/lazy (fn [] schema/pat))) (sc/string) (sc/array schema/field) schema/span])]))
 (def schema/clause (sc/tagged :clause @[(sc/array (sc/lazy (fn [] schema/pat))) (sc/lazy (fn [] schema/term)) schema/span]))
-
 (set schema/decl
      (sc/union @[
        (sc/tagged :decl/prec @[(sc/lit :infixl) nonneg-int (sc/string) schema/span])
        (sc/tagged :decl/prec @[(sc/lit :infixr) nonneg-int (sc/string) schema/span])
        (sc/tagged :decl/prec @[(sc/lit :prefix) nonneg-int (sc/string) schema/span])
        (sc/tagged :decl/prec @[(sc/lit :postfix) nonneg-int (sc/string) schema/span])
-       (sc/tagged :decl/data @[(sc/string) (sc/array schema/param) (sc/array schema/ctor) schema/span])
+       (sc/tagged :decl/data @[(sc/string) (sc/array schema/param) (sc/lazy (fn [] schema/type)) (sc/array schema/ctor) schema/span])
        (sc/tagged :decl/func @[(sc/string) (sc/lazy (fn [] schema/type)) (sc/array schema/clause) schema/span])]))
 
 (def schema/program


### PR DESCRIPTION
## Summary
- fix semantic evaluation and NbE equality edge cases, including `J` motives and explicit semantic handling for neutral conversions
- harden surface elaboration and schema handling for explicit sorts, string lambda params, and symbolic universe level algebra in the kernel
- add symbolic universe syntax across parsing, lowering, elaboration, and printing with regressions covering level ordering, parser failures, and end-to-end round trips