### PR TITLE
Refine size-change termination checking and expand regressions

### DIFF
--- a/src/elab.janet
+++ b/src/elab.janet
@@ -6,6 +6,7 @@
 (import ./frontend/surface/parser :as sp)
 (import ./sig :as s)
 (import ./coreTT :as tt)
+(import ./termination :as term)
 
 (defn env/lookup [env name]
   (var i (- (length env) 1))
@@ -786,10 +787,28 @@
     _
     (errorf "invalid declaration: %v" decl)))
 
+(defn- termination/function-decls [core-decls]
+  (reduce (fn [acc decl]
+            (match decl
+              [:core/func _ _ _ _ _] [;acc decl]
+              _ acc))
+          @[]
+          core-decls))
+
+(defn- termination/check! [core-decls]
+  (let [funcs (termination/function-decls core-decls)]
+    (when (> (length funcs) 0)
+      (let [result (term/sct* funcs)]
+        (when (not (result :ok))
+          (errorf "termination check failed: %s"
+                  (term/sc/problem-report (result :problems)))))))
+  core-decls)
+
 (defn elab/program [decls]
   (let [resolved (program/resolve-decls decls)
-        sig-env (sig/from-decls resolved)]
-    (map |(decl/elab sig-env $) resolved)))
+        sig-env (sig/from-decls resolved)
+        core-decls (map |(decl/elab sig-env $) resolved)]
+    (termination/check! core-decls)))
 
 (def exports
   {:elab/state elab/state

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -1,132 +1,524 @@
-# -- | Dual termination checking interface providing two independent
-# -- | strategies for ensuring program termination in dependent type theory.
-# -- | 
-# -- | This module exports:
-# -- |   - Size-Change Termination (SCT): first-order approach using
-# -- |     call matrices and SCC analysis
-# -- |   - Computability Path Ordering (CPO): type-based approach using
-# -- |     computability predicates and ordering relations
-# -- |
-# -- | Both approaches can be profiled independently to compare performance
-# -- | and effectiveness on different classes of recursive definitions.
+#!/usr/bin/env janet
 
-# -- | Size-Change Termination checker based on:
-# -- |   "The Size-Change Principle for Program Termination" by
-# -- |   Chin Soon Lee, Neil D. Jones, and Amir M. Ben-Amram (POPL'01),
-# -- | and
-# -- |   "A Predicative Analysis of Structural Recursion" by
-# -- |   Andreas Abel and Thorsten Altenkirch (JFP'02).
+(defn sc/relation-rank [rel]
+  (case rel
+    :lt 2
+    :eq 1
+    0))
 
-(defn sc/matrix [params call]
-  "Create size-change matrix for call"
-  (let [m (array/new (length params))]
-    (for [i 0 (length params)]
-      (let [row (array/new (length params))]
-        (for [j 0 (length params)]
+(defn sc/relation-max [r1 r2]
+  (if (> (sc/relation-rank r1) (sc/relation-rank r2)) r1 r2))
+
+(defn sc/relation-dominates? [r1 r2]
+  (>= (sc/relation-rank r1) (sc/relation-rank r2)))
+
+(defn sc/relation-mul [r1 r2]
+  (match [r1 r2]
+    [:lt :lt] :lt
+    [:lt :eq] :lt
+    [:eq :lt] :lt
+    [:eq :eq] :eq
+    _ :unknown))
+
+(defn sc/matrix [rows cols]
+  (let [m @[]]
+    (for i 0 rows
+      (let [row @[]]
+        (for j 0 cols
           (array/push row :unknown))
         (array/push m row)))
     m))
 
-(defn sc/compose [m1 m2]
-  "Compose two size-change matrices"
-  (let [n (length m1)
-        result (array/new n)]
-    (for [i 0 n]
-      (let [row (array/new n)]
-        (for [j 0 n]
-          (array/push row
-            (match [(get-in m1 [i j]) (get-in m2 [i j])]
-              [:dec _] :dec
-              [_ :dec] :dec
-              [:lt :lt] :lt
-              [:lt :unknown] :lt
-              [:unknown :lt] :lt
-              _ :unknown)))
-        (array/push result row)))
-    result))
+(defn sc/matrix-rows [m] (length m))
 
-(defn sc/sccs [graph]
-  "Find strongly connected components in call graph"
-  (let [visited @{} order [] components []]
-    (defn dfs [node stack]
-      (when (not (get visited node))
+(defn sc/matrix-cols [m]
+  (if (zero? (length m)) 0 (length (m 0))))
+
+(defn sc/matrix-set [m row col rel]
+  (put (m row) col rel)
+  m)
+
+(defn sc/matrix-get [m row col]
+  (get-in m [row col] :unknown))
+
+(defn sc/matrix-diagonal-has-lt? [m]
+  (let [dim (min (sc/matrix-rows m) (sc/matrix-cols m))]
+    (var i 0)
+    (var found false)
+    (while (< i dim)
+      (when (= (sc/matrix-get m i i) :lt)
+        (set found true)
+        (break))
+      (++ i))
+    found))
+
+(defn sc/matrix-diagonal [m]
+  (let [dim (min (sc/matrix-rows m) (sc/matrix-cols m))
+        out @[]]
+    (for i 0 dim
+      (array/push out (sc/matrix-get m i i)))
+    out))
+
+(defn sc/matrix-dominates? [m1 m2]
+  (and (= (sc/matrix-rows m1) (sc/matrix-rows m2))
+       (= (sc/matrix-cols m1) (sc/matrix-cols m2))
+       (let [rows (sc/matrix-rows m1)
+             cols (sc/matrix-cols m1)]
+         (var ok true)
+         (for i 0 rows
+           (for j 0 cols
+             (when (not (sc/relation-dominates? (sc/matrix-get m1 i j)
+                                                (sc/matrix-get m2 i j)))
+               (set ok false))))
+         ok)))
+
+(defn sc/compose [m1 m2]
+  (let [rows1 (sc/matrix-rows m1)
+        cols1 (sc/matrix-cols m1)
+        rows2 (sc/matrix-rows m2)
+        cols2 (sc/matrix-cols m2)]
+    (when (not= rows1 cols2)
+      (errorf "incompatible call matrices: %d x %d then %d x %d"
+              rows1 cols1 rows2 cols2))
+    (let [result (sc/matrix rows2 cols1)]
+      (for i 0 rows2
+        (for j 0 cols1
+          (var best :unknown)
+          (for k 0 cols2
+            (set best
+                 (sc/relation-max best
+                                  (sc/relation-mul (sc/matrix-get m2 i k)
+                                                   (sc/matrix-get m1 k j)))))
+          (sc/matrix-set result i j best)))
+      result)))
+
+(defn sc/filter-incomparable [matrices matrix]
+  (var i 0)
+  (var kept @[])
+  (while (< i (length matrices))
+    (let [existing (matrices i)]
+      (cond
+        (sc/matrix-dominates? (existing :matrix) (matrix :matrix))
+        (do
+          (set kept nil)
+          (set i (length matrices)))
+
+        (sc/matrix-dominates? (matrix :matrix) (existing :matrix))
+        nil
+
+        true
+        (array/push kept existing)))
+    (++ i))
+  (if kept [;kept matrix] matrices))
+
+(defn sc/base-proof [label callee]
+  [:sc/base-proof label callee])
+
+(defn sc/compose-proof [p1 p2]
+  [:sc/compose-proof p1 p2])
+
+(defn sc/proof->path [proof]
+  (match proof
+    [:sc/base-proof label callee] @[label callee]
+    [:sc/compose-proof p1 p2] (array/concat (sc/proof->path p1) (sc/proof->path p2))
+    _ @[]))
+
+(defn sc/call [from to matrix proof]
+  {:from from
+    :to to
+    :matrix matrix
+    :proof proof})
+
+(defn sc/call-compose [c1 c2]
+  (sc/call (c1 :from)
+           (c2 :to)
+            (sc/compose (c1 :matrix) (c2 :matrix))
+            (sc/compose-proof (c1 :proof) (c2 :proof))))
+
+(defn sc/graph []
+  {:arities @{}
+   :edges @{}})
+
+(defn sc/register [g name arity]
+  (put (g :arities) name arity)
+  (when (nil? (get (g :edges) name))
+    (put (g :edges) name @{}))
+  g)
+
+(defn sc/matrices [g from to]
+  (get (get (g :edges) from @{}) to @[]))
+
+(defn sc/add-call [g from to matrix]
+  (let [from-edges (get (g :edges) from @{})
+        old (get from-edges to @[])
+        next (sc/filter-incomparable old matrix)]
+    (put from-edges to next)
+    (put (g :edges) from from-edges)
+    (not= old next)))
+
+(defn sc/edge-targets [g from]
+  (keys (get (g :edges) from @{})))
+
+(defn sc/reverse-edges [g]
+  (let [rev @{}]
+    (eachp [name _] (g :arities)
+      (put rev name @[]))
+    (eachp [from tos] (g :edges)
+      (eachp [to calls] tos
+        (when (> (length calls) 0)
+          (let [targets (get rev to @[])]
+            (put rev to [;targets from])))))
+    rev))
+
+(defn sc/sccs [g]
+  (var visited @{})
+  (let [order @[]
+        rev (sc/reverse-edges g)
+        comps @[]]
+    (defn visit [node]
+      (unless (get visited node)
         (put visited node true)
-        (each [child (get graph node)]
-          (dfs child stack))
-        (array/push stack node)))
-    
-    (defn dfs-rev [node comp]
-      (when (not (get visited node))
+        (each next (sc/edge-targets g node)
+          (visit next))
+        (array/push order node)))
+    (defn visit-rev [node comp]
+      (unless (get visited node)
         (put visited node true)
         (array/push comp node)
-        (each [child (get graph node)]
-          (dfs-rev child comp))))
-    
-    (each [node (keys graph)]
-      (dfs node order))
-    
+        (each next (get rev node @[])
+          (visit-rev next comp))))
+    (eachp [name _] (g :arities)
+      (visit name))
     (set visited @{})
-    (while (length order)
-      (let [node (array/pop order)
-            comp []]
-        (dfs-rev node comp)
-        (when (length comp)
-          (array/push components comp))))
-    components))
+    (while (> (length order) 0)
+      (let [node (array/pop order)]
+        (unless (get visited node)
+          (let [comp @[]]
+            (visit-rev node comp)
+            (array/push comps comp)))))
+    comps))
 
-(defn sc/check-component [component matrices]
-  "Check termination for strongly connected component"
-  (let [n (length component)]
-    (for [i 0 n]
-      (let [m (get matrices (get component i))]
-        (for [j 0 (length m)]
-          (when (= (get-in m [j j]) :dec)
-            (return true)))))
-    false))
+(defn sc/component-recursive? [g comp]
+  (or (> (length comp) 1)
+      (and (= (length comp) 1)
+           (> (length (sc/matrices g (comp 0) (comp 0))) 0))))
 
-(defn sct [f]
-  "Size-Change Termination checker"
-  (let [call-graph {f []}
-        matrices {f []}
-        sccs (sc/sccs call-graph)]
-    (each [component sccs]
-      (when (not (sc/check-component component matrices))
-        (return {:ok false :reason "infinite loop detected"})))
-    {:ok true :m :sct}))
+(defn sc/matrix->string [m]
+  (string/join
+    (map (fn [row]
+           (string/join
+             (map (fn [rel]
+                    (case rel
+                      :lt "<"
+                      :eq "="
+                      "?"))
+                  row)
+             " "))
+         m)
+    " | "))
 
-(defn sct* [fs]
-  "Size-Change Termination for mutual recursion"
-  (let [call-graph {}
-        matrices {}]
-    (each [f fs]
-      (put call-graph f [])
-      (put matrices f []))
-    (let [sccs (sc/sccs call-graph)]
-      (each [component sccs]
-        (when (not (sc/check-component component matrices))
-          (return {:ok false :reason "mutual infinite loop detected"})))
-      {:ok true :m :sct*}))
+(defn sc/relation->string [rel]
+  (case rel
+    :lt "<"
+    :eq "="
+    "?"))
 
-# -- | Computability Path Ordering termination checker based on:
-# -- |   "Computability Closure: A Reconstruction of the
-# -- |    Predicative Analysis of Higher-Order Termination" by
-# -- |   Frédéric Blanqui (RTA'06),
-# -- | and
-# -- |   "Inductive Families Need Not Store Their Indices" by
-# -- |   James Chapman, Pierre-Évariste Dagand, Conor McBride,
-# -- |   and Peter Morris (ESOP'10).
+(defn sc/diagonal->string [m]
+  (let [diag (sc/matrix-diagonal m)]
+    (if (zero? (length diag))
+      "[]"
+      (string "["
+              (string/join (map sc/relation->string diag) " ")
+              "]"))))
+
+(defn sc/problem-summary [problem]
+  (let [path (string/join (sc/proof->path (problem :proof)) " -> ")]
+    (string/format "%s via %s [%s] diag=%s"
+                    (problem :name)
+                    path
+                    (sc/matrix->string (problem :matrix))
+                    (sc/diagonal->string (problem :matrix)))))
+
+(defn sc/problem-report [problems]
+  (string/join (map sc/problem-summary problems) "; "))
+
+(var sc/compare nil)
+
+(defn sc/immediate-subterms [tm]
+  (match tm
+    [:pair l r] @[l r]
+    [:fst p] @[p]
+    [:snd p] @[p]
+    [:fst [:pair l _]] @[l]
+    [:snd [:pair _ r]] @[r]
+    _ @[]))
+
+(defn sc/best-subterm-relation [term pat]
+  (let [subs (sc/immediate-subterms term)]
+    (reduce (fn [best subterm]
+              (let [rel (sc/compare subterm pat)]
+                (if (= rel :unknown)
+                  best
+                  (sc/relation-max best :lt))))
+            :unknown
+            subs)))
+
+(defn sc/spine [tm]
+  (var cur tm)
+  (var rev-args @[])
+  (while (and (tuple? cur) (= (cur 0) :app))
+    (array/push rev-args (cur 2))
+    (set cur (cur 1)))
+  [cur (reverse rev-args)])
+
+(defn sc/head-of [tm]
+  (match tm
+    [:app f _] (sc/head-of f)
+    [:fst p] (sc/head-of p)
+    [:snd p] (sc/head-of p)
+    _ tm))
+
+(defn sc/combine-subrelations [rels]
+  (reduce sc/relation-mul :eq rels))
+
+(defn sc/compare-con-args [args pats]
+  (if (not= (length args) (length pats))
+    :unknown
+    (let [rels @[]]
+      (for i 0 (length args)
+        (array/push rels (sc/compare (args i) (pats i))))
+      (sc/combine-subrelations rels))))
+
+(set sc/compare
+     (fn [term pat]
+       (match pat
+           [:pat/var x]
+           (cond
+             (= x "_") :unknown
+             (= term [:var x]) :eq
+             (not= :unknown (sc/best-subterm-relation term pat))
+             :lt
+             true :unknown)
+
+         [:pat/con ctor args]
+          (let [[head term-args] (sc/spine term)]
+            (if (and (tuple? head)
+                    (= (head 0) :var)
+                    (= (head 1) ctor)
+                    (= (length term-args) (length args)))
+             (sc/compare-con-args term-args args)
+             (reduce (fn [best subpat]
+                       (let [subrel (sc/compare term subpat)]
+                         (if (= subrel :unknown)
+                            best
+                            (sc/relation-max best :lt))))
+                      :unknown
+                      [;args (sc/immediate-subterms term)])))
+
+         _ :unknown)))
+
+(defn sc/call-matrix [caller-patterns call-args callee-arity]
+  (let [matrix (sc/matrix callee-arity (length caller-patterns))
+        used-args (slice call-args 0 callee-arity)]
+    (for i 0 callee-arity
+      (for j 0 (length caller-patterns)
+        (sc/matrix-set matrix i j (sc/compare (used-args i) (caller-patterns j)))))
+    matrix))
+
+(defn sc/call-head [tm target-arities]
+  (let [[head args] (sc/spine tm)]
+    (match head
+      [:var name]
+      (if-let [arity (get target-arities name)]
+        (when (>= (length args) arity)
+          [name (slice args 0 arity)])
+        nil)
+      _ nil)))
+
+(defn sc/maybe-record-call [calls target-arities caller-patterns tm]
+  (when-let [[callee args] (sc/call-head tm target-arities)]
+    (array/push calls
+                [callee (sc/call-matrix caller-patterns
+                                        args
+                                        (get target-arities callee))])))
+
+(defn sc/find-calls [target-arities caller-patterns term]
+  (let [calls @[]]
+    (defn walk [tm]
+      (match tm
+        [:app f x]
+        (do
+          (sc/maybe-record-call calls target-arities caller-patterns tm)
+          (walk f)
+          (walk x))
+
+        [:var _]
+        (sc/maybe-record-call calls target-arities caller-patterns tm)
+
+        [:lam body] (walk (body [:var (gensym)]))
+        [:t-pi A B] (do (walk A) (walk (B [:var (gensym)])))
+        [:t-sigma A B] (do (walk A) (walk (B [:var (gensym)])))
+        [:pair l r] (do (walk l) (walk r))
+        [:fst p] (do (sc/maybe-record-call calls target-arities caller-patterns tm)
+                     (walk p))
+        [:snd p] (do (sc/maybe-record-call calls target-arities caller-patterns tm)
+                     (walk p))
+        [:t-id A x y] (do (walk A) (walk x) (walk y))
+        [:t-refl x] (walk x)
+        [:t-J A x P d y p] (do (walk A) (walk x) (walk P) (walk d) (walk y) (walk p))
+        _ nil))
+    (walk term)
+    calls))
+
+(defn sc/clause-proof [name clause-index callee]
+  (sc/base-proof (string/format "%s[%d]" name (+ clause-index 1)) callee))
+
+(defn sc/header-proof [name section callee]
+  (sc/base-proof (string/format "%s:%s" name section) callee))
+
+(defn sc/add-clause-call [g name clause-index callee matrix]
+  (sc/add-call g
+               name
+               callee
+               (sc/call name
+                        callee
+                        matrix
+                        (sc/clause-proof name clause-index callee))))
+
+(defn sc/add-header-call [g name section callee matrix]
+  (sc/add-call g
+               name
+               callee
+               (sc/call name
+                        callee
+                        matrix
+                        (sc/header-proof name section callee))))
+
+(defn sc/build-graph [defs]
+  (let [g (sc/graph)
+        target-arities @{}]
+    (each def defs
+      (match def
+        [:core/func name params _ _ _]
+        (do
+          (put target-arities name (length params))
+          (sc/register g name (length params)))
+        _ nil))
+    (each def defs
+      (match def
+        [:core/func name _ result core-type clauses]
+        (do
+          (each [callee matrix] (sc/find-calls target-arities @[] core-type)
+            (sc/add-header-call g name "type" callee matrix))
+          (each [callee matrix] (sc/find-calls target-arities @[] result)
+            (sc/add-header-call g name "result" callee matrix))
+          (for clause-index 0 (length clauses)
+            (let [clause (clauses clause-index)]
+              (match clause
+                [:core/clause patterns body]
+                (each [callee matrix] (sc/find-calls target-arities patterns body)
+                  (sc/add-clause-call g name clause-index callee matrix))
+                _ nil))))
+        _ nil))
+    g))
+
+(defn sc/recursive-components [g]
+  (reduce (fn [acc comp]
+            (if (sc/component-recursive? g comp)
+              [;acc comp]
+              acc))
+          @[]
+          (sc/sccs g)))
+
+(defn sc/complete-component [g comp]
+  (for k 0 (length comp)
+    (let [mid (comp k)]
+      (for i 0 (length comp)
+        (let [from (comp i)
+              left (array/slice (sc/matrices g from mid))]
+          (when (> (length left) 0)
+            (for j 0 (length comp)
+              (let [to (comp j)
+                    right (array/slice (sc/matrices g mid to))]
+                (when (> (length right) 0)
+                  (each c1 left
+                    (each c2 right
+                      (sc/add-call g from to (sc/call-compose c1 c2)))))))))))))
+
+(defn sc/problems [g comps]
+  (let [out @[]]
+    (each comp comps
+      (each name comp
+        (each call (sc/matrices g name name)
+          (when (not (sc/matrix-diagonal-has-lt? (call :matrix)))
+            (array/push out {:name name
+                             :component comp
+                             :matrix (call :matrix)
+                             :proof (call :proof)})))))
+    out))
+
+(defn sc/check* [defs]
+  (let [g (sc/build-graph defs)
+        comps (sc/recursive-components g)
+        _ (each comp comps
+            (sc/complete-component g comp))
+        problems (sc/problems g comps)]
+    {:ok (zero? (length problems))
+     :m :sct
+     :graph g
+     :problems problems}))
+
+(defn sc/check-graph* [arities calls]
+  (let [g (sc/graph)]
+    (eachp [name arity] arities
+      (sc/register g name arity))
+    (each call calls
+      (sc/add-call g (call :from) (call :to) call))
+    (let [comps (sc/recursive-components g)
+          _ (each comp comps
+              (sc/complete-component g comp))
+          problems (sc/problems g comps)]
+      {:ok (zero? (length problems))
+       :m :sct
+       :graph g
+       :problems problems})))
+
+(defn sct [f-def]
+  (match f-def
+    [:core/func _ _ _ _ _] (sc/check* @[f-def])
+    _ {:ok true :m :sct :graph (sc/graph) :problems @[]}))
+
+(defn sct* [f-defs]
+  (sc/check* f-defs))
+
 (defn cpo [f]
-  "Computability Path Ordering"
-  {:ok true :m :cpo})
+  {:ok true :m :cpo :subject f})
 
 (defn cpo* [fs]
-  "Computability Path Ordering for mutual recursion"
-  {:ok true :m :cpo})
+  {:ok true :m :cpo :subject fs})
 
 (def exports
   {:sct sct
    :sct* sct*
    :cpo cpo
-   :cpo* cpo*})
+   :cpo* cpo*
+   :sc/call sc/call
+   :sc/check-graph* sc/check-graph*
+    :sc/compare sc/compare
+    :sc/compose sc/compose
+    :sc/diagonal->string sc/diagonal->string
+    :sc/find-calls sc/find-calls
+    :sc/filter-incomparable sc/filter-incomparable
+    :sc/matrix sc/matrix
+    :sc/matrix-get sc/matrix-get
+    :sc/matrix-diagonal-has-lt? sc/matrix-diagonal-has-lt?
+    :sc/matrix-dominates? sc/matrix-dominates?
+    :sc/matrix-set sc/matrix-set
+    :sc/matrix->string sc/matrix->string
+   :sc/problem-report sc/problem-report
+   :check-size-change sct
+   :check-mutual-size-change sct*
+   :check-cpo cpo
+   :check-mutual-cpo cpo*})
 
 exports

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -1,228 +1,132 @@
-#!/usr/bin/env janet
+# -- | Dual termination checking interface providing two independent
+# -- | strategies for ensuring program termination in dependent type theory.
+# -- | 
+# -- | This module exports:
+# -- |   - Size-Change Termination (SCT): first-order approach using
+# -- |     call matrices and SCC analysis
+# -- |   - Computability Path Ordering (CPO): type-based approach using
+# -- |     computability predicates and ordering relations
+# -- |
+# -- | Both approaches can be profiled independently to compare performance
+# -- | and effectiveness on different classes of recursive definitions.
 
-# Termination checking for Requiem
-# Two independent approaches for profiling
+# -- | Size-Change Termination checker based on:
+# -- |   "The Size-Change Principle for Program Termination" by
+# -- |   Chin Soon Lee, Neil D. Jones, and Amir M. Ben-Amram (POPL'01),
+# -- | and
+# -- |   "A Predicative Analysis of Structural Recursion" by
+# -- |   Andreas Abel and Thorsten Altenkirch (JFP'02).
 
-# -----------------------------------------------------------------------------
-# Size-change termination checker
-# -----------------------------------------------------------------------------
-
-(defn sc/lt [] [:decr true 1])
-(defn sc/le [] [:decr false 0])
-(defn sc/unknown [] :unknown)
-
-(defn sc/decr? [r]
-  (match r
-    [:decr true k] (> k 0)
-    _ false))
-
-(defn sc/mul [r1 r2]
-  (match [r1 r2]
-    [[:decr u1 k1] [:decr u2 k2]] [:decr (or u1 u2) (+ k1 k2)]
-    _ :unknown))
-
-(defn sc/matrix [rows cols]
-  {:rows rows
-   :cols cols
-   :data @{}})
-
-(defn sc/set [m row col r]
-  (when (and (>= row 0) (< row (m :rows))
-             (>= col 0) (< col (m :cols)))
-    (put (m :data) (+ (* row 1000) col) r))
-  m)
-
-(defn sc/get [m row col]
-  (get (m :data) (+ (* row 1000) col) (sc/unknown)))
+(defn sc/matrix [params call]
+  "Create size-change matrix for call"
+  (let [m (array/new (length params))]
+    (for [i 0 (length params)]
+      (let [row (array/new (length params))]
+        (for [j 0 (length params)]
+          (array/push row :unknown))
+        (array/push m row)))
+    m))
 
 (defn sc/compose [m1 m2]
-  (let [[rows1 cols1] [(m1 :rows) (m1 :cols)]
-        [rows2 cols2] [(m2 :rows) (m2 :cols)]]
-    (when (not= cols1 rows2)
-      (errorf "Matrix dimensions incompatible: %v x %v and %v x %v"
-              rows1 cols1 rows2 cols2))
+  "Compose two size-change matrices"
+  (let [n (length m1)
+        result (array/new n)]
+    (for [i 0 n]
+      (let [row (array/new n)]
+        (for [j 0 n]
+          (array/push row
+            (match [(get-in m1 [i j]) (get-in m2 [i j])]
+              [:dec _] :dec
+              [_ :dec] :dec
+              [:lt :lt] :lt
+              [:lt :unknown] :lt
+              [:unknown :lt] :lt
+              _ :unknown)))
+        (array/push result row)))
+    result))
+
+(defn sc/sccs [graph]
+  "Find strongly connected components in call graph"
+  (let [visited @{} order [] components []]
+    (defn dfs [node stack]
+      (when (not (get visited node))
+        (put visited node true)
+        (each [child (get graph node)]
+          (dfs child stack))
+        (array/push stack node)))
     
-    (let [result (sc/matrix rows1 cols2)]
-      (for i 0 rows1
-        (for j 0 cols2
-          (var best (sc/unknown))
-          (for k 0 cols1
-            (let [r1 (sc/get m1 i k)
-                  r2 (sc/get m2 k j)
-                  composed (sc/mul r1 r2)]
-              (set best (if (sc/decr? composed) composed best))))
-          (sc/set result i j best)))
-      result)))
-
-(defn sc/graph []
-  {:nodes @{}
-   :edges @{}})
-
-(defn sc/add-node [g f]
-  (put (g :nodes) f @{:arity 0})
-  g)
-
-(defn sc/add-call [g f1 f2 m]
-  (let [key [f1 f2]
-        current (get (g :edges) key @[])]
-    (array/push current m)
-    (put (g :edges) key current))
-  g)
-
-(defn sc/calls? [g f1 f2]
-  (not (nil? (get (g :edges) [f1 f2]))))
-
-(defn sc/sccs [g]
-  (var index 0)
-  (def stack @[])
-  (def indices @{})
-  (def lowlinks @{})
-  (def on-stack @{})
-  (def sccs @[])
-  
-  (defn strong-connect [v]
-    (put indices v index)
-    (put lowlinks v index)
-    (set index (+ index 1))
-    (array/push stack v)
-    (put on-stack v true)
+    (defn dfs-rev [node comp]
+      (when (not (get visited node))
+        (put visited node true)
+        (array/push comp node)
+        (each [child (get graph node)]
+          (dfs-rev child comp))))
     
-    (each w (keys (g :nodes))
-      (when (sc/calls? g v w)
-        (if (nil? (get indices w))
-          (do
-            (strong-connect w)
-            (put lowlinks v (min (get lowlinks v) (get lowlinks w))))
-          (when (get on-stack w)
-            (put lowlinks v (min (get lowlinks v) (get indices w)))))))
+    (each [node (keys graph)]
+      (dfs node order))
     
-    (when (= (get lowlinks v) (get indices v))
-      (def scc @[])
-      (var w nil)
-      (while true
-        (set w (array/pop stack))
-        (put on-stack w false)
-        (array/push scc w)
-        (when (= w v) (break)))
-      (array/push sccs scc)))
-  
-  (each v (keys (g :nodes))
-    (when (nil? (get indices v))
-      (strong-connect v)))
-  
-  sccs)
+    (set visited @{})
+    (while (length order)
+      (let [node (array/pop order)
+            comp []]
+        (dfs-rev node comp)
+        (when (length comp)
+          (array/push components comp))))
+    components))
 
-(defn sc/diagonal [m]
-  (let [dim (min (m :rows) (m :cols))]
-    (map |(sc/get m $ $) (range 0 dim))))
+(defn sc/check-component [component matrices]
+  "Check termination for strongly connected component"
+  (let [n (length component)]
+    (for [i 0 n]
+      (let [m (get matrices (get component i))]
+        (for [j 0 (length m)]
+          (when (= (get-in m [j j]) :dec)
+            (return true)))))
+    false))
 
-(defn sc/self-rec? [g scc]
-  (if (= (length scc) 1)
-    (sc/calls? g (scc 0) (scc 0))
-    (some |(sc/calls? g $ $) scc)))
+(defn sct [f]
+  "Size-Change Termination checker"
+  (let [call-graph {f []}
+        matrices {f []}
+        sccs (sc/sccs call-graph)]
+    (each [component sccs]
+      (when (not (sc/check-component component matrices))
+        (return {:ok false :reason "infinite loop detected"})))
+    {:ok true :m :sct}))
 
-(defn sc/check-scc [g scc]
-  (reduce (fn [acc val] (and acc val)) true
-          (map |(if (sc/calls? g $ $)
-                 (let [matrices (get (g :edges) [$ $])]
-                   (some |(some sc/decr? (sc/diagonal $)) matrices))
-                 true)
-               scc)))
+(defn sct* [fs]
+  "Size-Change Termination for mutual recursion"
+  (let [call-graph {}
+        matrices {}]
+    (each [f fs]
+      (put call-graph f [])
+      (put matrices f []))
+    (let [sccs (sc/sccs call-graph)]
+      (each [component sccs]
+        (when (not (sc/check-component component matrices))
+          (return {:ok false :reason "mutual infinite loop detected"})))
+      {:ok true :m :sct*}))
 
-(defn sc/check [g]
-  (let [sccs (sc/sccs g)
-        problems (filter
-                  (fn [scc] (and (sc/self-rec? g scc)
-                                 (not (sc/check-scc g scc))))
-                  sccs)]
-    {:terminates (empty? problems)
-     :problems problems
-     :method :size-change}))
+# -- | Computability Path Ordering termination checker based on:
+# -- |   "Computability Closure: A Reconstruction of the
+# -- |    Predicative Analysis of Higher-Order Termination" by
+# -- |   Frédéric Blanqui (RTA'06),
+# -- | and
+# -- |   "Inductive Families Need Not Store Their Indices" by
+# -- |   James Chapman, Pierre-Évariste Dagand, Conor McBride,
+# -- |   and Peter Morris (ESOP'10).
+(defn cpo [f]
+  "Computability Path Ordering"
+  {:ok true :m :cpo})
 
-(defn sc/head-of [t]
-  (match t
-    [:app f _] (sc/head-of f)
-    [:fst p] (sc/head-of p)
-    [:snd p] (sc/head-of p)
-    _ t))
-
-(defn sc/find-calls [f clauses]
-  (def calls @[])
-  
-  (defn search [term]
-    (match term
-      [:app fun args]
-      (do
-        (match (sc/head-of fun)
-          [:var name]
-          (when (= name f)
-            (let [arity (length args)
-                  m (sc/matrix arity arity)]
-              (for i 0 arity
-                (for j 0 arity
-                  (match (args i)
-                    [:var x] (when (= x (string "x" j))
-                               (sc/set m i j (sc/lt)))
-                    _ nil)))
-              (array/push calls [f m])))
-          _ nil)
-        (search fun)
-        (each arg args (search arg)))
-      _ nil))
-  
-  (each clause clauses
-    (match clause
-      [:core/clause _ body] (search body)
-      _ nil))
-  
-  calls)
-
-(defn check-size-change [f-def]
-  "Size-change termination checker (first-order)."
-  (match f-def
-    [:core/func name _ _ clauses _]
-    (let [g (sc/graph)]
-      (sc/add-node g name)
-      (each [callee m] (sc/find-calls name clauses)
-        (sc/add-node g callee)
-        (sc/add-call g name callee m))
-      (sc/check g))
-    _ {:terminates true :method :size-change}))
-
-(defn check-mutual-size-change [f-defs]
-  "Size-change termination for mutual recursion."
-  (let [g (sc/graph)]
-    (each f-def f-defs
-      (match f-def
-        [:core/func name _ _ clauses _]
-        (do
-          (sc/add-node g name)
-          (each [callee m] (sc/find-calls name clauses)
-            (sc/add-node g callee)
-            (sc/add-call g name callee m)))
-        _ nil))
-    (sc/check g)))
-
-# -----------------------------------------------------------------------------
-# Type-based/CPO termination checker
-# -----------------------------------------------------------------------------
-
-(defn cpo/check [f-def]
-  "Type-based termination checker (higher-order)."
-  {:terminates true
-   :method :cpo})
-
-(defn cpo/check-mutual [f-defs]
-  "Type-based termination for mutual recursion."
-  {:terminates true
-   :method :cpo})
-
-# -----------------------------------------------------------------------------
-# Main exports - separate checkers for profiling
-# -----------------------------------------------------------------------------
+(defn cpo* [fs]
+  "Computability Path Ordering for mutual recursion"
+  {:ok true :m :cpo})
 
 (def exports
-  {:check-size-change check-size-change
-   :check-mutual-size-change check-mutual-size-change
-   :check-cpo cpo/check
-   :check-mutual-cpo cpo/check-mutual})
+  {:sct sct
+   :sct* sct*
+   :cpo cpo
+   :cpo* cpo*})
+
+exports

--- a/test/Elab/Elab.janet
+++ b/test/Elab/Elab.janet
@@ -128,9 +128,101 @@
     (= (result 0) :t-sigma))
   "Dispatch aliases normalize sigma spellings")
 
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "loop"
+         @[[ :bind "n" [:atom "Nat"] ]]
+         [:atom "Nat"]
+         @[
+           [:clause @[[:pat/con "zero" @[]]] [:atom "zero"]]
+           [:clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+            [:list @[[:atom "loop"] [:list @[[:atom "succ"] [:atom "n"]]]]]]
+         ]]
+      ]))
+  "Program elaboration rejects non-terminating recursion"
+  "termination check failed: loop")
+
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "header-left"
+         @[]
+         [:atom "header-right"]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+        [:decl/func "header-right"
+         @[]
+         [:atom "header-left"]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+      ]))
+  "Program elaboration rejects recursive cycles in function headers"
+  "termination check failed: header-left")
+
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "self-header"
+         @[]
+         [:atom "self-header"]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+      ]))
+  "Program elaboration rejects direct self-recursion in function headers"
+  "termination check failed: self-header")
+
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "header-pi-left"
+         @[]
+         [:list @[[:atom "Pi"]
+                  [:list @[[:atom "Ann"] [:atom "x"] [:atom "Nat"]]]
+                  [:atom "header-pi-right"]]]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+        [:decl/func "header-pi-right"
+         @[]
+         [:list @[[:atom "Sigma"]
+                  [:list @[[:atom "x:"] [:atom "Nat"]]]
+                  [:atom "."]
+                  [:atom "header-pi-left"]]]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+      ]))
+  "Program elaboration rejects recursive cycles in dependent headers"
+  "termination check failed: header-pi")
+
+(test/assert suite
+  (let [program (e/elab/program
+                  @[
+                    [:decl/func "plus"
+                     @[[ :bind "m" [:atom "Nat"] ]
+                       [ :bind "n" [:atom "Nat"] ]]
+                     [:atom "Nat"]
+                     @[
+                       [:clause @[[:pat/con "zero" @[]] [:pat/var "n"]] [:atom "n"]]
+                       [:clause @[[:pat/con "succ" @[[:pat/var "m"]]] [:pat/var "n"]]
+                        [:list @[[:atom "succ"]
+                                 [:list @[[:atom "plus"] [:atom "m"] [:atom "n"]]]]]
+                       ]]]
+                   ])]
+    (= ((program 0) 0) :core/func))
+  "Program elaboration accepts structurally recursive functions")
+
 (test/assert suite
   (let [motive-body [:list @[[ :atom "Id" ]
-                              [:atom "Type1"]
+                               [:atom "Type1"]
                               [:atom "Type0"]
                               [:atom "y"]]]
         motive-inner [:list @[[ :atom "fn" ]

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -1,0 +1,307 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/termination :as term)
+
+(def suite (test/start-suite "Termination Size Change"))
+
+(def nat-type [:var "Nat"])
+
+(def plus-decl
+  [:core/func "plus"
+   @[[ :bind "m" nat-type ]
+     [ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]] [:pat/var "n"]]
+      [:var "n"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "m"]]] [:pat/var "n"]]
+      [:app [:var "succ"] [:app [:app [:var "plus"] [:var "m"]] [:var "n"]]]]]])
+
+(def loop-decl
+  [:core/func "loop"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "loop"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def even-decl
+  [:core/func "even"
+   @[[ :bind "n" nat-type ]]
+   [:var "Bool"]
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "true"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "odd"] [:var "n"]]]]])
+
+(def odd-decl
+  [:core/func "odd"
+   @[[ :bind "n" nat-type ]]
+   [:var "Bool"]
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "false"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "even"] [:var "n"]]]]])
+
+(def ping-decl
+  [:core/func "ping"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "pong"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def pong-decl
+  [:core/func "pong"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "ping"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def shrink-left-decl
+  [:core/func "shrink-left"
+   @[[ :bind "m" nat-type ]
+     [ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]] [:pat/var "n"]]
+      [:var "n"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "m"]]] [:pat/var "n"]]
+      [:app [:var "one-arg"] [:var "m"]]]]])
+
+(def one-arg-decl
+  [:core/func "one-arg"
+   @[[ :bind "k" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+      [:core/clause @[[:pat/con "succ" @[[:pat/var "k"]]]]
+       [:app [:app [:var "shrink-left"] [:var "k"]] [:var "k"]]]]])
+
+(def apply-loop-decl
+  [:core/func "apply-loop"
+   @[[ :bind "f" [:var "Nat->Nat"] ]
+     [ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "f"] [:pat/var "n"]]
+      [:app [:app [:var "apply-loop"] [:app [:var "f"] [:var "n"]]] [:var "n"]]]]])
+
+(def proj-loop-decl
+  [:core/func "proj-loop"
+   @[[ :bind "p" [:var "PairNat"] ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "p"]]
+      [:app [:var "proj-loop"] [:fst [:var "p"]]]]]])
+
+(def header-left-decl
+  [:core/func "header-left"
+   @[]
+   [:var "header-right"]
+   [:var "header-right"]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def header-right-decl
+  [:core/func "header-right"
+   @[]
+   [:var "header-left"]
+   [:var "header-left"]
+   @[
+      [:core/clause @[] [:var "zero"]]]])
+
+(def self-header-decl
+  [:core/func "self-header"
+   @[]
+   [:var "self-header"]
+   [:var "self-header"]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def complex-header-left-decl
+  [:core/func "complex-header-left"
+   @[]
+   [:t-pi [:var "Nat"] (fn [x] [:var "complex-header-right"])]
+   [:t-pi [:var "Nat"] (fn [x] [:var "complex-header-right"])]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def complex-header-right-decl
+  [:core/func "complex-header-right"
+   @[]
+   [:t-sigma [:var "Nat"] (fn [x] [:var "complex-header-left"])]
+   [:t-sigma [:var "Nat"] (fn [x] [:var "complex-header-left"])]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def tri-a-decl
+  [:core/func "tri-a"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "tri-b"] [:var "n"]]]]])
+
+(def tri-b-decl
+  [:core/func "tri-b"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "tri-c"] [:var "n"]]]]])
+
+(def tri-c-decl
+  [:core/func "tri-c"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "tri-a"] [:var "n"]]]]])
+
+(def bad-tri-a-decl
+  [:core/func "bad-tri-a"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "bad-tri-b"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def bad-tri-b-decl
+  [:core/func "bad-tri-b"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "bad-tri-c"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def bad-tri-c-decl
+  [:core/func "bad-tri-c"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "bad-tri-a"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(test/assert suite
+  ((term/sct plus-decl) :ok)
+  "Primitive recursion on a constructor argument passes SCT")
+
+(let [result (term/sct loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "loop"))
+    "Self recursion without size decrease fails SCT"))
+
+(test/assert suite
+  ((term/sct* @[even-decl odd-decl]) :ok)
+  "Mutual recursion with constructor descent passes SCT")
+
+(let [result (term/sct* @[ping-decl pong-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 2)
+         (all |(= (length ($ :component)) 2) (result :problems)))
+    "Mutual recursion without any decrease fails SCT"))
+
+(test/assert suite
+  ((term/sct* @[shrink-left-decl one-arg-decl]) :ok)
+  "SCT composes non-square call matrices across mutual recursion")
+
+(let [result (term/sct apply-loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "apply-loop"))
+    "SCT does not treat higher-order applications as structural descent"))
+
+(test/assert suite
+  ((term/sct proj-loop-decl) :ok)
+  "SCT still recognizes projection subterms as decreasing")
+
+(let [result (term/sct* @[header-left-decl header-right-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 2)
+         (not (nil? (string/find "header-left:type" (term/sc/problem-report (result :problems)))))
+         (not (nil? (string/find "diag=[]" (term/sc/problem-report (result :problems))))))
+    "SCT rejects recursive cycles appearing in function headers"))
+
+(let [result (term/sct self-header-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "self-header")
+         (not (nil? (string/find "self-header:type" (term/sc/problem-report (result :problems))))))
+    "SCT rejects direct self-recursion in function headers"))
+
+(let [result (term/sct* @[complex-header-left-decl complex-header-right-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 2)
+         (not (nil? (string/find "complex-header-left:type" (term/sc/problem-report (result :problems)))))
+         (not (nil? (string/find "complex-header-right:type" (term/sc/problem-report (result :problems))))))
+    "SCT rejects recursive cycles found under dependent header terms"))
+
+(test/assert suite
+  ((term/sct* @[tri-a-decl tri-b-decl tri-c-decl]) :ok)
+  "SCT closes decreasing three-function cycles")
+
+(let [result (term/sct* @[bad-tri-a-decl bad-tri-b-decl bad-tri-c-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 3)
+         (all |(= (length ($ :component)) 3) (result :problems)))
+    "SCT rejects non-decreasing three-function cycles"))
+
+(test/assert suite
+  (not (nil? (string/find "loop" (term/sc/problem-report ((term/sct loop-decl) :problems)))))
+  "Problem reports include offending function names")
+
+(test/assert suite
+  (let [report (term/sc/problem-report ((term/sct* @[ping-decl pong-decl]) :problems))]
+    (and (not (nil? (string/find "ping[2]" report)))
+         (not (nil? (string/find "pong" report)))))
+  "Problem reports include call-path information")
+
+(test/end-suite suite)

--- a/test/Termination/SizeChangeCompare.janet
+++ b/test/Termination/SizeChangeCompare.janet
@@ -1,0 +1,147 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/termination :as term)
+
+(def suite (test/start-suite "Termination Size Change Compare"))
+
+(defn wrap [matrix]
+  {:from "f" :to "f" :matrix matrix :proof [:sc/base-proof "p" "f"]})
+
+(defn mk-matrix [rows cols entries]
+  (let [m (term/sc/matrix rows cols)]
+    (each [row col rel] entries
+      (term/sc/matrix-set m row col rel))
+    m))
+
+(test/assert suite
+  (= :eq (term/sc/compare [:var "x"] [:pat/var "x"]))
+  "Variables compare equal to the same pattern variable")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:var "y"] [:pat/var "x"]))
+  "Different variables do not compare as decreasing")
+
+(test/assert suite
+  (= :lt (term/sc/compare [:fst [:var "p"]] [:pat/var "p"]))
+  "First projections count as structural descent")
+
+(test/assert suite
+  (= :lt (term/sc/compare [:snd [:var "p"]] [:pat/var "p"]))
+  "Second projections count as structural descent")
+
+(test/assert suite
+  (= :lt (term/sc/compare [:pair [:var "x"] [:var "y"]] [:pat/var "x"]))
+  "Pair components count as subterms of the whole pair")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:app [:var "f"] [:var "x"]] [:pat/var "f"]))
+  "Higher-order applications are not mistaken for descent on the head")
+
+(test/assert suite
+  (= :eq (term/sc/compare [:app [:var "succ"] [:var "n"]]
+                          [:pat/con "succ" @[[:pat/var "n"]]]))
+  "Matching constructor applications compare componentwise")
+
+(test/assert suite
+  (= :eq (term/sc/compare [:app [:var "succ"] [:var "zero"]]
+                          [:pat/con "succ" @[[:pat/con "zero" @[]]]]))
+  "Nested constructor patterns compare exactly when heads and arguments match")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:app [:var "zero"] [:var "n"]]
+                               [:pat/con "succ" @[[:pat/var "n"]]]))
+  "Different constructor heads do not compare spuriously")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:var "x"] [:pat/var "_"]))
+  "Wildcard patterns do not produce size information")
+
+(test/assert suite
+  (let [unknown (wrap (mk-matrix 1 1 @[]))
+        equal (wrap (mk-matrix 1 1 @[[0 0 :eq]]))
+        strong (wrap (mk-matrix 1 1 @[[0 0 :lt]]))
+        filtered1 (term/sc/filter-incomparable @[unknown] equal)
+        filtered2 (term/sc/filter-incomparable filtered1 strong)]
+    (and (= 1 (length filtered1))
+         (= :eq (term/sc/matrix-get ((filtered1 0) :matrix) 0 0))
+         (= 1 (length filtered2))
+         (= :lt (term/sc/matrix-get ((filtered2 0) :matrix) 0 0))))
+  "Antichain filtering replaces weaker comparable matrices")
+
+(test/assert suite
+  (let [m1 (wrap (mk-matrix 2 2 @[[0 0 :lt]]))
+        m2 (wrap (mk-matrix 2 2 @[[1 1 :lt]]))
+        filtered (term/sc/filter-incomparable @[m1] m2)]
+    (= 2 (length filtered)))
+  "Antichain filtering keeps incomparable matrices")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:lam (fn [y] [:app [:var "loop"] [:var "x"]])])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls under lambdas")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-pi [:var "Nat"] (fn [y] [:app [:var "loop"] [:var "x"]])])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls under dependent pis")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-sigma [:var "Nat"] (fn [y] [:app [:var "loop"] [:var "x"]])])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls under dependent sigmas")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-id [:var "Nat"] [:var "x"] [:app [:var "loop"] [:var "x"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls inside identity types")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-J [:var "Nat"]
+                                        [:var "x"]
+                                        [:lam (fn [y] [:app [:var "loop"] [:var "x"]])]
+                                        [:var "zero"]
+                                        [:var "x"]
+                                        [:t-refl [:var "x"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls inside J motives")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "p"]]
+                                  [:fst [:app [:var "loop"] [:fst [:var "p"]]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :lt (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery preserves projection-based descent in discovered calls")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "f"]]
+                                  [:app [:var "f"] [:app [:var "loop"] [:var "f"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery records recursive calls inside non-recursive applications only once")
+
+(test/end-suite suite)

--- a/test/Termination/SizeChangeGraph.janet
+++ b/test/Termination/SizeChangeGraph.janet
@@ -1,0 +1,333 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/termination :as term)
+
+(def suite (test/start-suite "Termination Size Change Graph"))
+
+(defn mk-matrix [rows cols entries]
+  (let [m (term/sc/matrix rows cols)]
+    (each [row col rel] entries
+      (term/sc/matrix-set m row col rel))
+    m))
+
+(defn rel->string [rel]
+  (case rel
+    :lt "<"
+    :eq "="
+    "?"))
+
+(defn mk-self-call [name rel label]
+  (term/sc/call name name
+                (if (= rel :unknown)
+                  (mk-matrix 1 1 @[])
+                  (mk-matrix 1 1 @[[0 0 rel]]))
+                [:sc/base-proof label name]))
+
+(defn mk-edge [from to rel label]
+  (term/sc/call from to
+                (if (= rel :unknown)
+                  (mk-matrix 1 1 @[])
+                  (mk-matrix 1 1 @[[0 0 rel]]))
+                [:sc/base-proof label to]))
+
+(defn wrap [matrix]
+  {:from "f" :to "f" :matrix matrix :proof [:sc/base-proof "p" "f"]})
+
+(defn ref-rel-mul [r1 r2]
+  (match [r1 r2]
+    [:lt :lt] :lt
+    [:lt :eq] :lt
+    [:eq :lt] :lt
+    [:eq :eq] :eq
+    _ :unknown))
+
+(defn ref-rel-rank [rel]
+  (case rel
+    :lt 2
+    :eq 1
+    0))
+
+(defn ref-rel-max [r1 r2]
+  (if (> (ref-rel-rank r1) (ref-rel-rank r2)) r1 r2))
+
+(defn ref-check-1x1 [nodes edges]
+  (let [best @{}]
+    (each from nodes
+      (let [row @{}]
+        (each to nodes
+          (put row to :unknown))
+        (put best from row)))
+    (each [from to rel] edges
+      (put (best from) to (ref-rel-max ((best from) to) rel)))
+    (var changed true)
+    (while changed
+      (set changed false)
+      (each mid nodes
+        (each from nodes
+          (each to nodes
+            (let [candidate (ref-rel-mul ((best from) mid) ((best mid) to))
+                  current ((best from) to)]
+              (when (> (ref-rel-rank candidate) (ref-rel-rank current))
+                (put (best from) to candidate)
+                (set changed true)))))))
+    (all (fn [node]
+           (= ((best node) node) :lt))
+         nodes)))
+
+(test/assert suite
+  (let [left (mk-matrix 1 2 @[[0 0 :eq] [0 1 :lt]])
+        right (mk-matrix 2 1 @[[0 0 :lt] [1 0 :eq]])
+        composed (term/sc/compose left right)]
+    (and (= "< < | = <" (term/sc/matrix->string composed))
+         (term/sc/matrix-diagonal-has-lt? composed)))
+  "Matrix composition keeps strongest relation across paths")
+
+(test/assert suite
+  (let [strong (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+        weak (mk-matrix 2 2 @[[1 1 :eq]])]
+    (and (term/sc/matrix-dominates? strong weak)
+         (not (term/sc/matrix-dominates? weak strong))))
+  "Matrix dominance orders precise matrices above weaker ones")
+
+(test/assert suite
+  (= "[< ? =]" (term/sc/diagonal->string (mk-matrix 3 3 @[[0 0 :lt] [2 2 :eq]])))
+  "Diagonal rendering exposes decreasing evidence")
+
+(test/assert suite
+  (let [ack-calls @[
+          (term/sc/call "ack" "ack"
+                        (mk-matrix 2 2 @[[0 0 :lt]])
+                        [:sc/base-proof "ack-1" "ack"])
+          (term/sc/call "ack" "ack"
+                        (mk-matrix 2 2 @[[0 0 :eq] [1 1 :lt]])
+                        [:sc/base-proof "ack-2" "ack"])]
+        result (term/sc/check-graph* @{"ack" 2} ack-calls)]
+    (result :ok))
+  "Arend-style mixed decreasing self-call matrices pass SCT closure")
+
+(let [result (term/sc/check-graph*
+               @{"f" 4}
+               @[
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :lt]])
+                               [:sc/base-proof "f-1" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :lt]])
+                               [:sc/base-proof "f-2" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :lt]])
+                               [:sc/base-proof "f-3" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :eq] [3 3 :lt]])
+                               [:sc/base-proof "f-4" "f"])])]
+  (test/assert suite
+    (result :ok)
+    "Arend artificial decreasing chain closes successfully"))
+
+(let [result (term/sc/check-graph*
+               @{"f" 4}
+               @[
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :lt]])
+                               [:sc/base-proof "f-1" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :lt]])
+                               [:sc/base-proof "f-2" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :lt]])
+                               [:sc/base-proof "f-3" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :eq] [3 3 :eq]])
+                               [:sc/base-proof "f-4" "f"])])]
+  (test/assert suite
+    (not (result :ok))
+    "Arend artificial non-decreasing chain is rejected"))
+
+(let [result (term/sc/check-graph*
+               @{"f" 4}
+               @[
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[1 1 :lt] [3 3 :eq]])
+                               [:sc/base-proof "f-2" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[1 1 :eq] [2 2 :lt] [3 3 :eq]])
+                               [:sc/base-proof "f-3" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[3 3 :lt]])
+                               [:sc/base-proof "f-1" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :lt] [1 1 :eq] [2 2 :eq] [3 3 :eq]])
+                               [:sc/base-proof "f-4" "f"])])]
+  (test/assert suite
+    (result :ok)
+    "Arend artificial incomparable matrices still yield a decreasing cycle"))
+
+(let [result (term/sc/check-graph*
+               @{"h" 2 "f" 2 "g" 2}
+               @[
+                 (term/sc/call "h" "h"
+                               (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+                               [:sc/base-proof "h-h-1" "h"])
+                 (term/sc/call "h" "h"
+                               (mk-matrix 2 2 @[[0 0 :eq] [1 1 :lt]])
+                               [:sc/base-proof "h-h-2" "h"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 2 2 @[[0 1 :lt]])
+                               [:sc/base-proof "f-f" "f"])
+                 (term/sc/call "f" "h"
+                               (mk-matrix 2 2 @[])
+                               [:sc/base-proof "f-h" "h"])
+                 (term/sc/call "f" "g"
+                               (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+                               [:sc/base-proof "f-g" "g"])
+                 (term/sc/call "g" "f"
+                               (mk-matrix 2 2 @[[0 0 :eq] [1 1 :eq]])
+                               [:sc/base-proof "g-f" "f"])
+                 (term/sc/call "g" "g"
+                               (mk-matrix 2 2 @[[0 0 :lt]])
+                               [:sc/base-proof "g-g" "g"])
+                 (term/sc/call "g" "h"
+                               (mk-matrix 2 2 @[])
+                               [:sc/base-proof "g-h" "h"])])]
+  (test/assert suite
+    (not (result :ok))
+    "Arend mixed graph counterexample is rejected"))
+
+(let [result (term/sc/check-graph*
+               @{"v" 1}
+               @[
+                 (term/sc/call "v" "v"
+                               (mk-matrix 1 1 @[])
+                               [:sc/base-proof "unknown" "v"])
+                 (term/sc/call "v" "v"
+                               (mk-matrix 1 1 @[[0 0 :eq]])
+                               [:sc/base-proof "equal" "v"])
+                 (term/sc/call "v" "v"
+                               (mk-matrix 1 1 @[[0 0 :lt]])
+                               [:sc/base-proof "lt" "v"])])]
+  (test/assert suite
+    (and (result :ok)
+         (zero? (length (result :problems))))
+    "Dominating matrices do not interfere with a decreasing witness"))
+
+(let [triples @[
+        @[:unknown :unknown :unknown]
+        @[:unknown :unknown :eq]
+        @[:unknown :eq :eq]
+        @[:eq :eq :eq]
+        @[:lt :unknown :unknown]
+        @[:unknown :lt :eq]
+        @[:eq :eq :lt]
+        @[:lt :lt :lt]]]
+  (each triple triples
+    (let [r1 (triple 0)
+          r2 (triple 1)
+          r3 (triple 2)
+          result (term/sc/check-graph*
+                   @{"f" 1}
+                   @[(mk-self-call "f" r1 "r1")
+                     (mk-self-call "f" r2 "r2")
+                     (mk-self-call "f" r3 "r3")])
+          expect (or (= r1 :lt) (= r2 :lt) (= r3 :lt))]
+      (test/assertf suite
+                    (= expect (result :ok))
+                    "Generated single-node 1x1 SCT cases match diagonal intuition"
+                    (string "rels=" (rel->string r1) "," (rel->string r2) "," (rel->string r3)
+                            " got=" (if (result :ok) "ok" "fail"))))))
+
+(let [pairs @[
+        @[:unknown :unknown]
+        @[:unknown :eq]
+        @[:eq :eq]
+        @[:lt :unknown]
+        @[:unknown :lt]
+        @[:eq :lt]
+        @[:lt :eq]
+        @[:lt :lt]]]
+  (each pair pairs
+    (let [r1 (pair 0)
+          r2 (pair 1)
+          result (term/sc/check-graph*
+                   @{"f" 1 "g" 1}
+                   @[(mk-edge "f" "g" r1 "f-g")
+                     (mk-edge "g" "f" r2 "g-f")])
+          expect (and (not= r1 :unknown)
+                      (not= r2 :unknown)
+                      (or (= r1 :lt) (= r2 :lt)))]
+      (test/assertf suite
+                    (= expect (result :ok))
+                    "Generated two-node 1x1 cycles match composed diagonal intuition"
+                    (string "cycle=" (rel->string r1) "," (rel->string r2)
+                            " got=" (if (result :ok) "ok" "fail"))))))
+
+(let [m00 (wrap (mk-matrix 2 2 @[[0 0 :lt]]))
+      m11 (wrap (mk-matrix 2 2 @[[1 1 :lt]]))
+      meq (wrap (mk-matrix 2 2 @[[0 0 :eq] [1 1 :eq]]))
+      mboth (wrap (mk-matrix 2 2 @[[0 0 :lt] [1 1 :lt]]))
+      kept1 (term/sc/filter-incomparable @[m00] m11)
+      kept2 (term/sc/filter-incomparable kept1 meq)
+      kept3 (term/sc/filter-incomparable kept2 mboth)]
+  (test/assertf suite
+                (and (= 2 (length kept1))
+                     (= 3 (length kept2))
+                     (= 1 (length kept3))
+                     (= "< ? | ? <" (term/sc/matrix->string ((kept3 0) :matrix))))
+                "2x2 antichain filtering keeps incomparable matrices then collapses to stronger witness"
+                (string "after1=" (length kept1) " after2=" (length kept2) " after3=" (length kept3)
+                        " final=" (term/sc/matrix->string ((kept3 0) :matrix)))) )
+
+(let [left (mk-matrix 2 2 @[[0 0 :eq] [1 1 :lt]])
+      right (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+      composed (term/sc/compose left right)]
+  (test/assertf suite
+                (and (= "< ? | ? <" (term/sc/matrix->string composed))
+                     (term/sc/matrix-diagonal-has-lt? composed))
+                "2x2 composition preserves decreases on distinct coordinates"
+                (term/sc/matrix->string composed)))
+
+(let [cases @[
+        {:label "self-unknown"
+         :nodes @["f"]
+         :edges @[["f" "f" :unknown]]
+         :calls @[(mk-self-call "f" :unknown "u")]}
+        {:label "self-eq"
+         :nodes @["f"]
+         :edges @[["f" "f" :eq]]
+         :calls @[(mk-self-call "f" :eq "e")]}
+        {:label "self-lt"
+         :nodes @["f"]
+         :edges @[["f" "f" :lt]]
+         :calls @[(mk-self-call "f" :lt "l")]}
+        {:label "mutual-eq-eq"
+         :nodes @["f" "g"]
+         :edges @[["f" "g" :eq] ["g" "f" :eq]]
+         :calls @[(mk-edge "f" "g" :eq "fg") (mk-edge "g" "f" :eq "gf")]}
+        {:label "mutual-lt-eq"
+         :nodes @["f" "g"]
+         :edges @[["f" "g" :lt] ["g" "f" :eq]]
+         :calls @[(mk-edge "f" "g" :lt "fg") (mk-edge "g" "f" :eq "gf")]}
+        {:label "mutual-lt-unknown"
+         :nodes @["f" "g"]
+         :edges @[["f" "g" :lt] ["g" "f" :unknown]]
+         :calls @[(mk-edge "f" "g" :lt "fg") (mk-edge "g" "f" :unknown "gf")]}
+        {:label "mixed-self-and-mutual"
+         :nodes @["f" "g"]
+         :edges @[["f" "f" :eq] ["f" "g" :lt] ["g" "f" :eq]]
+         :calls @[(mk-self-call "f" :eq "ff") (mk-edge "f" "g" :lt "fg") (mk-edge "g" "f" :eq "gf")]}
+        {:label "both-self-lt"
+         :nodes @["f" "g"]
+         :edges @[["f" "f" :lt] ["g" "g" :lt]]
+         :calls @[(mk-self-call "f" :lt "ff") (mk-self-call "g" :lt "gg")]}]]
+  (each specimen cases
+    (let [arities @{}
+          _ (each node (specimen :nodes)
+              (put arities node 1))
+          reference (ref-check-1x1 (specimen :nodes) (specimen :edges))
+          actual ((term/sc/check-graph* arities (specimen :calls)) :ok)]
+      (test/assertf suite
+                    (= reference actual)
+                    "Reference 1x1 closure agrees with SCT on fixed small graphs"
+                    (string (specimen :label) " ref=" reference " actual=" actual)))))
+
+(test/end-suite suite)


### PR DESCRIPTION
## Summary
- tighten size-change termination checking by fixing recursive-argument comparisons, composing call matrices across recursive components, and rejecting recursive cycles that arise in function headers
- run SCT during elaboration so non-terminating definitions fail early, while keeping the current `cpo` entrypoints as stubs
- add focused regression suites for end-to-end programs, internal compare/call discovery logic, and graph/matrix closure behavior including a tiny reference checker for small 1x1 cases

## Testing
- janet test/Termination/SizeChange.janet
- janet test/Termination/SizeChangeCompare.janet
- janet test/Termination/SizeChangeGraph.janet
- janet test/Elab/Elab.janet
- jpm test