### PR TITLE
fix HAMT GC marking for stored semantic values

### DIFF
--- a/native/hamt.c
+++ b/native/hamt.c
@@ -189,12 +189,36 @@ static void h_collect(void *n, JanetTable *t, JanetArray *keys) {
 /* Janet abstract type */
 typedef struct { void *root; size_t size; Arena *arena; } Hamt;
 
+static void hamt_mark_node(void *n) {
+    if (!n) return;
+    if (is_leaf(n)) {
+        for (Leaf *l = get_ptr(n); l; l = l->next) {
+            janet_mark(l->val);
+        }
+        return;
+    }
+    Node *node = n;
+    int c = h_pop(node->bits);
+    for (int i = 0; i < c; i++) hamt_mark_node(node->kids[i]);
+}
+
 static int hamt_gc(void *p, size_t sz) {
     (void)sz; arena_dec(((Hamt *)p)->arena);
     return 0;
 }
 
-static const JanetAbstractType hamt_type = { "hamt", hamt_gc };
+static int hamt_gcmark(void *p, size_t sz) {
+    (void)sz;
+    hamt_mark_node(((Hamt *)p)->root);
+    return 0;
+}
+
+static const JanetAbstractType hamt_type = {
+    "hamt",
+    hamt_gc,
+    hamt_gcmark,
+    JANET_ATEND_GCMARK
+};
 
 /* Janet API */
 static Janet cf_new(int32_t argc, Janet *argv) {

--- a/test/Native/Hamt.janet
+++ b/test/Native/Hamt.janet
@@ -1,5 +1,7 @@
 (import ../../build/hamt :as h)
 (import ../Utils/TestRunner :as test)
+(import ../../src/coreTT :as c)
+(import ../Utils/Generators :as gen)
 
 (def suite (test/start-suite "Native HAMT"))
 
@@ -54,5 +56,27 @@
 
 # Force collisions (hash is complex to force, but large N helps coverage)
 # We rely on the large dataset to trigger splitting nodes
+
+(defn hamt/stress-semantic-values [seed rounds]
+  (let [rng (gen/rng seed)]
+    (var ok true)
+    (var i 0)
+    (while (and ok (< i rounds))
+      (let [sample (gen/gen-inferable-judgment rng)]
+        (try
+          (c/infer (sample :ctx) (sample :term))
+          ([err]
+            (set ok false)
+            (print "HAMT semantic-value corruption:")
+            (print "  seed =" seed)
+            (print "  round =" i)
+            (print "  kind =" (sample :kind))
+            (print "  err =" err))))
+      (++ i))
+    ok))
+
+(test/assert suite
+  (hamt/stress-semantic-values "3" 3000)
+  "HAMT retains semantic values across GC pressure")
 
 (test/end-suite suite)


### PR DESCRIPTION
## Summary
- mark Janet values stored inside HAMT leaves during GC so semantic values in contexts are not collected early
- add a native HAMT regression that stresses inferable judgments under the previously failing seeded scenario
- stabilize the flaky property suites that depended on HAMT-backed contexts

## Testing
- jpm build
- jpm test
- repeated `jpm test` runs in the isolated fix branch