### PR TITLE
Refine size-change termination checking and expand regressions

### DIFF
--- a/src/elab.janet
+++ b/src/elab.janet
@@ -6,6 +6,7 @@
 (import ./frontend/surface/parser :as sp)
 (import ./sig :as s)
 (import ./coreTT :as tt)
+(import ./termination :as term)
 
 (defn env/lookup [env name]
   (var i (- (length env) 1))
@@ -786,10 +787,28 @@
     _
     (errorf "invalid declaration: %v" decl)))
 
+(defn- termination/function-decls [core-decls]
+  (reduce (fn [acc decl]
+            (match decl
+              [:core/func _ _ _ _ _] [;acc decl]
+              _ acc))
+          @[]
+          core-decls))
+
+(defn- termination/check! [core-decls]
+  (let [funcs (termination/function-decls core-decls)]
+    (when (> (length funcs) 0)
+      (let [result (term/sct* funcs)]
+        (when (not (result :ok))
+          (errorf "termination check failed: %s"
+                  (term/sc/problem-report (result :problems)))))))
+  core-decls)
+
 (defn elab/program [decls]
   (let [resolved (program/resolve-decls decls)
-        sig-env (sig/from-decls resolved)]
-    (map |(decl/elab sig-env $) resolved)))
+        sig-env (sig/from-decls resolved)
+        core-decls (map |(decl/elab sig-env $) resolved)]
+    (termination/check! core-decls)))
 
 (def exports
   {:elab/state elab/state

--- a/src/elab.janet
+++ b/src/elab.janet
@@ -790,7 +790,7 @@
 (defn- termination/function-decls [core-decls]
   (reduce (fn [acc decl]
             (match decl
-              [:core/func _ _ _ _ _] [;acc decl]
+              [:core/func _ _ _ _ _] (do (array/push acc decl) acc)
               _ acc))
           @[]
           core-decls))

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -1,132 +1,524 @@
-# -- | Dual termination checking interface providing two independent
-# -- | strategies for ensuring program termination in dependent type theory.
-# -- | 
-# -- | This module exports:
-# -- |   - Size-Change Termination (SCT): first-order approach using
-# -- |     call matrices and SCC analysis
-# -- |   - Computability Path Ordering (CPO): type-based approach using
-# -- |     computability predicates and ordering relations
-# -- |
-# -- | Both approaches can be profiled independently to compare performance
-# -- | and effectiveness on different classes of recursive definitions.
+#!/usr/bin/env janet
 
-# -- | Size-Change Termination checker based on:
-# -- |   "The Size-Change Principle for Program Termination" by
-# -- |   Chin Soon Lee, Neil D. Jones, and Amir M. Ben-Amram (POPL'01),
-# -- | and
-# -- |   "A Predicative Analysis of Structural Recursion" by
-# -- |   Andreas Abel and Thorsten Altenkirch (JFP'02).
+(defn sc/relation-rank [rel]
+  (case rel
+    :lt 2
+    :eq 1
+    0))
 
-(defn sc/matrix [params call]
-  "Create size-change matrix for call"
-  (let [m (array/new (length params))]
-    (for [i 0 (length params)]
-      (let [row (array/new (length params))]
-        (for [j 0 (length params)]
+(defn sc/relation-max [r1 r2]
+  (if (> (sc/relation-rank r1) (sc/relation-rank r2)) r1 r2))
+
+(defn sc/relation-dominates? [r1 r2]
+  (>= (sc/relation-rank r1) (sc/relation-rank r2)))
+
+(defn sc/relation-mul [r1 r2]
+  (match [r1 r2]
+    [:lt :lt] :lt
+    [:lt :eq] :lt
+    [:eq :lt] :lt
+    [:eq :eq] :eq
+    _ :unknown))
+
+(defn sc/matrix [rows cols]
+  (let [m @[]]
+    (for i 0 rows
+      (let [row @[]]
+        (for j 0 cols
           (array/push row :unknown))
         (array/push m row)))
     m))
 
-(defn sc/compose [m1 m2]
-  "Compose two size-change matrices"
-  (let [n (length m1)
-        result (array/new n)]
-    (for [i 0 n]
-      (let [row (array/new n)]
-        (for [j 0 n]
-          (array/push row
-            (match [(get-in m1 [i j]) (get-in m2 [i j])]
-              [:dec _] :dec
-              [_ :dec] :dec
-              [:lt :lt] :lt
-              [:lt :unknown] :lt
-              [:unknown :lt] :lt
-              _ :unknown)))
-        (array/push result row)))
-    result))
+(defn sc/matrix-rows [m] (length m))
 
-(defn sc/sccs [graph]
-  "Find strongly connected components in call graph"
-  (let [visited @{} order [] components []]
-    (defn dfs [node stack]
-      (when (not (get visited node))
+(defn sc/matrix-cols [m]
+  (if (zero? (length m)) 0 (length (m 0))))
+
+(defn sc/matrix-set [m row col rel]
+  (put (m row) col rel)
+  m)
+
+(defn sc/matrix-get [m row col]
+  (get-in m [row col] :unknown))
+
+(defn sc/matrix-diagonal-has-lt? [m]
+  (let [dim (min (sc/matrix-rows m) (sc/matrix-cols m))]
+    (var i 0)
+    (var found false)
+    (while (< i dim)
+      (when (= (sc/matrix-get m i i) :lt)
+        (set found true)
+        (break))
+      (++ i))
+    found))
+
+(defn sc/matrix-diagonal [m]
+  (let [dim (min (sc/matrix-rows m) (sc/matrix-cols m))
+        out @[]]
+    (for i 0 dim
+      (array/push out (sc/matrix-get m i i)))
+    out))
+
+(defn sc/matrix-dominates? [m1 m2]
+  (and (= (sc/matrix-rows m1) (sc/matrix-rows m2))
+       (= (sc/matrix-cols m1) (sc/matrix-cols m2))
+       (let [rows (sc/matrix-rows m1)
+             cols (sc/matrix-cols m1)]
+         (var ok true)
+         (for i 0 rows
+           (for j 0 cols
+             (when (not (sc/relation-dominates? (sc/matrix-get m1 i j)
+                                                (sc/matrix-get m2 i j)))
+               (set ok false))))
+         ok)))
+
+(defn sc/compose [m1 m2]
+  (let [rows1 (sc/matrix-rows m1)
+        cols1 (sc/matrix-cols m1)
+        rows2 (sc/matrix-rows m2)
+        cols2 (sc/matrix-cols m2)]
+    (when (not= rows1 cols2)
+      (errorf "incompatible call matrices: %d x %d then %d x %d"
+              rows1 cols1 rows2 cols2))
+    (let [result (sc/matrix rows2 cols1)]
+      (for i 0 rows2
+        (for j 0 cols1
+          (var best :unknown)
+          (for k 0 cols2
+            (set best
+                 (sc/relation-max best
+                                  (sc/relation-mul (sc/matrix-get m2 i k)
+                                                   (sc/matrix-get m1 k j)))))
+          (sc/matrix-set result i j best)))
+      result)))
+
+(defn sc/filter-incomparable [matrices matrix]
+  (var i 0)
+  (var kept @[])
+  (while (< i (length matrices))
+    (let [existing (matrices i)]
+      (cond
+        (sc/matrix-dominates? (existing :matrix) (matrix :matrix))
+        (do
+          (set kept nil)
+          (set i (length matrices)))
+
+        (sc/matrix-dominates? (matrix :matrix) (existing :matrix))
+        nil
+
+        true
+        (array/push kept existing)))
+    (++ i))
+  (if kept [;kept matrix] matrices))
+
+(defn sc/base-proof [label callee]
+  [:sc/base-proof label callee])
+
+(defn sc/compose-proof [p1 p2]
+  [:sc/compose-proof p1 p2])
+
+(defn sc/proof->path [proof]
+  (match proof
+    [:sc/base-proof label callee] @[label callee]
+    [:sc/compose-proof p1 p2] (array/concat (sc/proof->path p1) (sc/proof->path p2))
+    _ @[]))
+
+(defn sc/call [from to matrix proof]
+  {:from from
+    :to to
+    :matrix matrix
+    :proof proof})
+
+(defn sc/call-compose [c1 c2]
+  (sc/call (c1 :from)
+           (c2 :to)
+            (sc/compose (c1 :matrix) (c2 :matrix))
+            (sc/compose-proof (c1 :proof) (c2 :proof))))
+
+(defn sc/graph []
+  {:arities @{}
+   :edges @{}})
+
+(defn sc/register [g name arity]
+  (put (g :arities) name arity)
+  (when (nil? (get (g :edges) name))
+    (put (g :edges) name @{}))
+  g)
+
+(defn sc/matrices [g from to]
+  (get (get (g :edges) from @{}) to @[]))
+
+(defn sc/add-call [g from to matrix]
+  (let [from-edges (get (g :edges) from @{})
+        old (get from-edges to @[])
+        next (sc/filter-incomparable old matrix)]
+    (put from-edges to next)
+    (put (g :edges) from from-edges)
+    (not= old next)))
+
+(defn sc/edge-targets [g from]
+  (keys (get (g :edges) from @{})))
+
+(defn sc/reverse-edges [g]
+  (let [rev @{}]
+    (eachp [name _] (g :arities)
+      (put rev name @[]))
+    (eachp [from tos] (g :edges)
+      (eachp [to calls] tos
+        (when (> (length calls) 0)
+          (let [targets (get rev to @[])]
+            (put rev to [;targets from])))))
+    rev))
+
+(defn sc/sccs [g]
+  (var visited @{})
+  (let [order @[]
+        rev (sc/reverse-edges g)
+        comps @[]]
+    (defn visit [node]
+      (unless (get visited node)
         (put visited node true)
-        (each [child (get graph node)]
-          (dfs child stack))
-        (array/push stack node)))
-    
-    (defn dfs-rev [node comp]
-      (when (not (get visited node))
+        (each next (sc/edge-targets g node)
+          (visit next))
+        (array/push order node)))
+    (defn visit-rev [node comp]
+      (unless (get visited node)
         (put visited node true)
         (array/push comp node)
-        (each [child (get graph node)]
-          (dfs-rev child comp))))
-    
-    (each [node (keys graph)]
-      (dfs node order))
-    
+        (each next (get rev node @[])
+          (visit-rev next comp))))
+    (eachp [name _] (g :arities)
+      (visit name))
     (set visited @{})
-    (while (length order)
-      (let [node (array/pop order)
-            comp []]
-        (dfs-rev node comp)
-        (when (length comp)
-          (array/push components comp))))
-    components))
+    (while (> (length order) 0)
+      (let [node (array/pop order)]
+        (unless (get visited node)
+          (let [comp @[]]
+            (visit-rev node comp)
+            (array/push comps comp)))))
+    comps))
 
-(defn sc/check-component [component matrices]
-  "Check termination for strongly connected component"
-  (let [n (length component)]
-    (for [i 0 n]
-      (let [m (get matrices (get component i))]
-        (for [j 0 (length m)]
-          (when (= (get-in m [j j]) :dec)
-            (return true)))))
-    false))
+(defn sc/component-recursive? [g comp]
+  (or (> (length comp) 1)
+      (and (= (length comp) 1)
+           (> (length (sc/matrices g (comp 0) (comp 0))) 0))))
 
-(defn sct [f]
-  "Size-Change Termination checker"
-  (let [call-graph {f []}
-        matrices {f []}
-        sccs (sc/sccs call-graph)]
-    (each [component sccs]
-      (when (not (sc/check-component component matrices))
-        (return {:ok false :reason "infinite loop detected"})))
-    {:ok true :m :sct}))
+(defn sc/matrix->string [m]
+  (string/join
+    (map (fn [row]
+           (string/join
+             (map (fn [rel]
+                    (case rel
+                      :lt "<"
+                      :eq "="
+                      "?"))
+                  row)
+             " "))
+         m)
+    " | "))
 
-(defn sct* [fs]
-  "Size-Change Termination for mutual recursion"
-  (let [call-graph {}
-        matrices {}]
-    (each [f fs]
-      (put call-graph f [])
-      (put matrices f []))
-    (let [sccs (sc/sccs call-graph)]
-      (each [component sccs]
-        (when (not (sc/check-component component matrices))
-          (return {:ok false :reason "mutual infinite loop detected"})))
-      {:ok true :m :sct*}))
+(defn sc/relation->string [rel]
+  (case rel
+    :lt "<"
+    :eq "="
+    "?"))
 
-# -- | Computability Path Ordering termination checker based on:
-# -- |   "Computability Closure: A Reconstruction of the
-# -- |    Predicative Analysis of Higher-Order Termination" by
-# -- |   Frédéric Blanqui (RTA'06),
-# -- | and
-# -- |   "Inductive Families Need Not Store Their Indices" by
-# -- |   James Chapman, Pierre-Évariste Dagand, Conor McBride,
-# -- |   and Peter Morris (ESOP'10).
+(defn sc/diagonal->string [m]
+  (let [diag (sc/matrix-diagonal m)]
+    (if (zero? (length diag))
+      "[]"
+      (string "["
+              (string/join (map sc/relation->string diag) " ")
+              "]"))))
+
+(defn sc/problem-summary [problem]
+  (let [path (string/join (sc/proof->path (problem :proof)) " -> ")]
+    (string/format "%s via %s [%s] diag=%s"
+                    (problem :name)
+                    path
+                    (sc/matrix->string (problem :matrix))
+                    (sc/diagonal->string (problem :matrix)))))
+
+(defn sc/problem-report [problems]
+  (string/join (map sc/problem-summary problems) "; "))
+
+(var sc/compare nil)
+
+(defn sc/immediate-subterms [tm]
+  (match tm
+    [:pair l r] @[l r]
+    [:fst p] @[p]
+    [:snd p] @[p]
+    [:fst [:pair l _]] @[l]
+    [:snd [:pair _ r]] @[r]
+    _ @[]))
+
+(defn sc/best-subterm-relation [term pat]
+  (let [subs (sc/immediate-subterms term)]
+    (reduce (fn [best subterm]
+              (let [rel (sc/compare subterm pat)]
+                (if (= rel :unknown)
+                  best
+                  (sc/relation-max best :lt))))
+            :unknown
+            subs)))
+
+(defn sc/spine [tm]
+  (var cur tm)
+  (var rev-args @[])
+  (while (and (tuple? cur) (= (cur 0) :app))
+    (array/push rev-args (cur 2))
+    (set cur (cur 1)))
+  [cur (reverse rev-args)])
+
+(defn sc/head-of [tm]
+  (match tm
+    [:app f _] (sc/head-of f)
+    [:fst p] (sc/head-of p)
+    [:snd p] (sc/head-of p)
+    _ tm))
+
+(defn sc/combine-subrelations [rels]
+  (reduce sc/relation-mul :eq rels))
+
+(defn sc/compare-con-args [args pats]
+  (if (not= (length args) (length pats))
+    :unknown
+    (let [rels @[]]
+      (for i 0 (length args)
+        (array/push rels (sc/compare (args i) (pats i))))
+      (sc/combine-subrelations rels))))
+
+(set sc/compare
+     (fn [term pat]
+       (match pat
+           [:pat/var x]
+           (cond
+             (= x "_") :unknown
+             (= term [:var x]) :eq
+             (not= :unknown (sc/best-subterm-relation term pat))
+             :lt
+             true :unknown)
+
+         [:pat/con ctor args]
+          (let [[head term-args] (sc/spine term)]
+            (if (and (tuple? head)
+                    (= (head 0) :var)
+                    (= (head 1) ctor)
+                    (= (length term-args) (length args)))
+             (sc/compare-con-args term-args args)
+             (reduce (fn [best subpat]
+                       (let [subrel (sc/compare term subpat)]
+                         (if (= subrel :unknown)
+                            best
+                            (sc/relation-max best :lt))))
+                      :unknown
+                      [;args (sc/immediate-subterms term)])))
+
+         _ :unknown)))
+
+(defn sc/call-matrix [caller-patterns call-args callee-arity]
+  (let [matrix (sc/matrix callee-arity (length caller-patterns))
+        used-args (slice call-args 0 callee-arity)]
+    (for i 0 callee-arity
+      (for j 0 (length caller-patterns)
+        (sc/matrix-set matrix i j (sc/compare (used-args i) (caller-patterns j)))))
+    matrix))
+
+(defn sc/call-head [tm target-arities]
+  (let [[head args] (sc/spine tm)]
+    (match head
+      [:var name]
+      (if-let [arity (get target-arities name)]
+        (when (>= (length args) arity)
+          [name (slice args 0 arity)])
+        nil)
+      _ nil)))
+
+(defn sc/maybe-record-call [calls target-arities caller-patterns tm]
+  (when-let [[callee args] (sc/call-head tm target-arities)]
+    (array/push calls
+                [callee (sc/call-matrix caller-patterns
+                                        args
+                                        (get target-arities callee))])))
+
+(defn sc/find-calls [target-arities caller-patterns term]
+  (let [calls @[]]
+    (defn walk [tm]
+      (match tm
+        [:app f x]
+        (do
+          (sc/maybe-record-call calls target-arities caller-patterns tm)
+          (walk f)
+          (walk x))
+
+        [:var _]
+        (sc/maybe-record-call calls target-arities caller-patterns tm)
+
+        [:lam body] (walk (body [:var (gensym)]))
+        [:t-pi A B] (do (walk A) (walk (B [:var (gensym)])))
+        [:t-sigma A B] (do (walk A) (walk (B [:var (gensym)])))
+        [:pair l r] (do (walk l) (walk r))
+        [:fst p] (do (sc/maybe-record-call calls target-arities caller-patterns tm)
+                     (walk p))
+        [:snd p] (do (sc/maybe-record-call calls target-arities caller-patterns tm)
+                     (walk p))
+        [:t-id A x y] (do (walk A) (walk x) (walk y))
+        [:t-refl x] (walk x)
+        [:t-J A x P d y p] (do (walk A) (walk x) (walk P) (walk d) (walk y) (walk p))
+        _ nil))
+    (walk term)
+    calls))
+
+(defn sc/clause-proof [name clause-index callee]
+  (sc/base-proof (string/format "%s[%d]" name (+ clause-index 1)) callee))
+
+(defn sc/header-proof [name section callee]
+  (sc/base-proof (string/format "%s:%s" name section) callee))
+
+(defn sc/add-clause-call [g name clause-index callee matrix]
+  (sc/add-call g
+               name
+               callee
+               (sc/call name
+                        callee
+                        matrix
+                        (sc/clause-proof name clause-index callee))))
+
+(defn sc/add-header-call [g name section callee matrix]
+  (sc/add-call g
+               name
+               callee
+               (sc/call name
+                        callee
+                        matrix
+                        (sc/header-proof name section callee))))
+
+(defn sc/build-graph [defs]
+  (let [g (sc/graph)
+        target-arities @{}]
+    (each def defs
+      (match def
+        [:core/func name params _ _ _]
+        (do
+          (put target-arities name (length params))
+          (sc/register g name (length params)))
+        _ nil))
+    (each def defs
+      (match def
+        [:core/func name _ result core-type clauses]
+        (do
+          (each [callee matrix] (sc/find-calls target-arities @[] core-type)
+            (sc/add-header-call g name "type" callee matrix))
+          (each [callee matrix] (sc/find-calls target-arities @[] result)
+            (sc/add-header-call g name "result" callee matrix))
+          (for clause-index 0 (length clauses)
+            (let [clause (clauses clause-index)]
+              (match clause
+                [:core/clause patterns body]
+                (each [callee matrix] (sc/find-calls target-arities patterns body)
+                  (sc/add-clause-call g name clause-index callee matrix))
+                _ nil))))
+        _ nil))
+    g))
+
+(defn sc/recursive-components [g]
+  (reduce (fn [acc comp]
+            (if (sc/component-recursive? g comp)
+              [;acc comp]
+              acc))
+          @[]
+          (sc/sccs g)))
+
+(defn sc/complete-component [g comp]
+  (for k 0 (length comp)
+    (let [mid (comp k)]
+      (for i 0 (length comp)
+        (let [from (comp i)
+              left (array/slice (sc/matrices g from mid))]
+          (when (> (length left) 0)
+            (for j 0 (length comp)
+              (let [to (comp j)
+                    right (array/slice (sc/matrices g mid to))]
+                (when (> (length right) 0)
+                  (each c1 left
+                    (each c2 right
+                      (sc/add-call g from to (sc/call-compose c1 c2)))))))))))))
+
+(defn sc/problems [g comps]
+  (let [out @[]]
+    (each comp comps
+      (each name comp
+        (each call (sc/matrices g name name)
+          (when (not (sc/matrix-diagonal-has-lt? (call :matrix)))
+            (array/push out {:name name
+                             :component comp
+                             :matrix (call :matrix)
+                             :proof (call :proof)})))))
+    out))
+
+(defn sc/check* [defs]
+  (let [g (sc/build-graph defs)
+        comps (sc/recursive-components g)
+        _ (each comp comps
+            (sc/complete-component g comp))
+        problems (sc/problems g comps)]
+    {:ok (zero? (length problems))
+     :m :sct
+     :graph g
+     :problems problems}))
+
+(defn sc/check-graph* [arities calls]
+  (let [g (sc/graph)]
+    (eachp [name arity] arities
+      (sc/register g name arity))
+    (each call calls
+      (sc/add-call g (call :from) (call :to) call))
+    (let [comps (sc/recursive-components g)
+          _ (each comp comps
+              (sc/complete-component g comp))
+          problems (sc/problems g comps)]
+      {:ok (zero? (length problems))
+       :m :sct
+       :graph g
+       :problems problems})))
+
+(defn sct [f-def]
+  (match f-def
+    [:core/func _ _ _ _ _] (sc/check* @[f-def])
+    _ {:ok true :m :sct :graph (sc/graph) :problems @[]}))
+
+(defn sct* [f-defs]
+  (sc/check* f-defs))
+
 (defn cpo [f]
-  "Computability Path Ordering"
-  {:ok true :m :cpo})
+  {:ok true :m :cpo :subject f})
 
 (defn cpo* [fs]
-  "Computability Path Ordering for mutual recursion"
-  {:ok true :m :cpo})
+  {:ok true :m :cpo :subject fs})
 
 (def exports
   {:sct sct
    :sct* sct*
    :cpo cpo
-   :cpo* cpo*})
+   :cpo* cpo*
+   :sc/call sc/call
+   :sc/check-graph* sc/check-graph*
+    :sc/compare sc/compare
+    :sc/compose sc/compose
+    :sc/diagonal->string sc/diagonal->string
+    :sc/find-calls sc/find-calls
+    :sc/filter-incomparable sc/filter-incomparable
+    :sc/matrix sc/matrix
+    :sc/matrix-get sc/matrix-get
+    :sc/matrix-diagonal-has-lt? sc/matrix-diagonal-has-lt?
+    :sc/matrix-dominates? sc/matrix-dominates?
+    :sc/matrix-set sc/matrix-set
+    :sc/matrix->string sc/matrix->string
+   :sc/problem-report sc/problem-report
+   :check-size-change sct
+   :check-mutual-size-change sct*
+   :check-cpo cpo
+   :check-mutual-cpo cpo*})
 
 exports

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -109,7 +109,11 @@
         true
         (array/push kept existing)))
     (++ i))
-  (if kept [;kept matrix] matrices))
+  (if kept
+    (do
+      (array/push kept matrix)
+      kept)
+    matrices))
 
 (defn sc/base-proof [label callee]
   [:sc/base-proof label callee])
@@ -167,7 +171,8 @@
       (eachp [to calls] tos
         (when (> (length calls) 0)
           (let [targets (get rev to @[])]
-            (put rev to [;targets from])))))
+            (array/push targets from)
+            (put rev to targets)))))
     rev))
 
 (defn sc/sccs [g]
@@ -313,7 +318,7 @@
                             best
                             (sc/relation-max best :lt))))
                       :unknown
-                      [;args (sc/immediate-subterms term)])))
+                      (array/concat args (sc/immediate-subterms term)))))
 
          _ :unknown)))
 
@@ -425,7 +430,9 @@
 (defn sc/recursive-components [g]
   (reduce (fn [acc comp]
             (if (sc/component-recursive? g comp)
-              [;acc comp]
+              (do
+                (array/push acc comp)
+                acc)
               acc))
           @[]
           (sc/sccs g)))

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -263,42 +263,60 @@
     (set cur
          (match cur
            [:app f x]
-           (let [f* (sc/whnf f)]
-             (match f*
-               [:lam body]
+            (let [f* (sc/whnf f)]
+              (match f*
+                [:lam body]
                (do
                  (set changed true)
                  (body x))
                _
                (if (not= f* f)
-                 (do
-                   (set changed true)
-                   [:app f* x])
-                 cur)))
-           [:fst [:pair l _]]
-           (do
-             (set changed true)
-             l)
-           [:snd [:pair _ r]]
-           (do
-             (set changed true)
-             r)
-           _ cur)))
+                  (do
+                    (set changed true)
+                    [:app f* x])
+                  cur)))
+            [:fst p]
+            (let [p* (sc/whnf p)]
+              (match p*
+                [:pair l _]
+                (do
+                  (set changed true)
+                  l)
+                _
+                (if (not= p* p)
+                  (do
+                    (set changed true)
+                    [:fst p*])
+                  cur)))
+            [:snd p]
+            (let [p* (sc/whnf p)]
+              (match p*
+                [:pair _ r]
+                (do
+                  (set changed true)
+                  r)
+                _
+                (if (not= p* p)
+                  (do
+                    (set changed true)
+                    [:snd p*])
+                  cur)))
+            _ cur)))
   cur)
 
-(defn sc/reduced-relation [term pat]
+(defn sc/reduced-relation [term pat bound-names]
   (match (sc/whnf term)
-    [:fst [:pair l _]] (sc/compare l pat)
-    [:snd [:pair _ r]] (sc/compare r pat)
+    [:fst [:pair l _]] (sc/compare l pat bound-names)
+    [:snd [:pair _ r]] (sc/compare r pat bound-names)
     _ :unknown))
 
-(defn sc/best-subterm-relation [term pat]
+(defn sc/best-subterm-relation [term pat bound-names]
   (let [subs (sc/immediate-subterms term)]
     (reduce (fn [best subterm]
-              (let [rel (sc/compare subterm pat)]
-                (if (= rel :unknown)
-                  best
-                  (sc/relation-max best :lt))))
+              (let [rel (sc/compare subterm pat bound-names)]
+                 (if (= rel :unknown)
+                   best
+                   (sc/relation-max best :lt))))
             :unknown
             subs)))
 
@@ -320,51 +338,53 @@
 (defn sc/combine-subrelations [rels]
   (reduce sc/relation-mul :eq rels))
 
-(defn sc/compare-con-args [args pats]
+(defn sc/compare-con-args [args pats bound-names]
   (if (not= (length args) (length pats))
     :unknown
     (let [rels @[]]
       (for i 0 (length args)
-        (array/push rels (sc/compare (args i) (pats i))))
+        (array/push rels (sc/compare (args i) (pats i) bound-names)))
       (sc/combine-subrelations rels))))
 
 (set sc/compare
-     (fn [term pat]
-       (let [term* (sc/whnf term)]
-         (match pat
-            [:pat/var x]
-            (cond
-              (= x "_") :unknown
-              (= term* [:var x]) :eq
-              (not= :unknown (sc/reduced-relation term* pat))
-              (sc/reduced-relation term* pat)
-              (not= :unknown (sc/best-subterm-relation term* pat))
-              :lt
-              true :unknown)
+     (fn [term pat &opt bound-names]
+       (let [bound-names (or bound-names @{})
+             term* (sc/whnf term)]
+          (match pat
+             [:pat/var x]
+             (cond
+               (= x "_") :unknown
+               (= term* [:var x]) :eq
+               (not= :unknown (sc/reduced-relation term* pat bound-names))
+               (sc/reduced-relation term* pat bound-names)
+               (not= :unknown (sc/best-subterm-relation term* pat bound-names))
+               :lt
+               true :unknown)
 
-           [:pat/con ctor args]
-            (let [[head term-args] (sc/spine term*)]
-              (if (and (tuple? head)
-                      (= (head 0) :var)
-                      (= (head 1) ctor)
-                      (= (length term-args) (length args)))
-               (sc/compare-con-args term-args args)
-               (reduce (fn [best subpat]
-                         (let [subrel (sc/compare term* subpat)]
-                           (if (= subrel :unknown)
-                              best
-                              (sc/relation-max best :lt))))
-                        :unknown
-                        (array/concat args (sc/immediate-subterms term*)))))
+            [:pat/con ctor args]
+             (let [[head term-args] (sc/spine term*)]
+               (if (and (tuple? head)
+                       (= (head 0) :var)
+                       (not (get bound-names (head 1)))
+                       (= (head 1) ctor)
+                       (= (length term-args) (length args)))
+                (sc/compare-con-args term-args args bound-names)
+                (reduce (fn [best subpat]
+                          (let [subrel (sc/compare term* subpat bound-names)]
+                            (if (= subrel :unknown)
+                               best
+                               (sc/relation-max best :lt))))
+                         :unknown
+                         (array/concat args (sc/immediate-subterms term*)))))
 
            _ :unknown))))
 
-(defn sc/call-matrix [caller-patterns call-args callee-arity]
+(defn sc/call-matrix [caller-patterns call-args callee-arity bound-names]
   (let [matrix (sc/matrix callee-arity (length caller-patterns))
         used-args (slice call-args 0 callee-arity)]
     (for i 0 callee-arity
       (for j 0 (length caller-patterns)
-        (sc/matrix-set matrix i j (sc/compare (used-args i) (caller-patterns j)))))
+        (sc/matrix-set matrix i j (sc/compare (used-args i) (caller-patterns j) bound-names))))
     matrix))
 
 (defn sc/call-head [tm target-arities bound-names]
@@ -383,8 +403,9 @@
   (when-let [[callee args] (sc/call-head tm target-arities bound-names)]
     (array/push calls
                  [callee (sc/call-matrix caller-patterns
-                                         args
-                                         (get target-arities callee))])))
+                                          args
+                                          (get target-arities callee)
+                                          bound-names)])))
 
 (defn sc/pattern-bound-names [patterns]
   (reduce (fn [acc pat]
@@ -440,7 +461,21 @@
                      (walk p bound-names))
         [:t-id A x y] (do (walk A bound-names) (walk x bound-names) (walk y bound-names))
         [:t-refl x] (walk x bound-names)
-        [:t-J A x P d y p] (do (walk A bound-names) (walk x bound-names) (walk P bound-names) (walk d bound-names) (walk y bound-names) (walk p bound-names))
+        [:t-J A x P d y p]
+        (do
+          (walk A bound-names)
+          (walk x bound-names)
+          (if (function? P)
+            (let [fresh-y (gensym)
+                  fresh-p (gensym)
+                  next-bound (table/clone bound-names)]
+              (put next-bound fresh-y true)
+              (put next-bound fresh-p true)
+              (walk (P [:var fresh-y] [:var fresh-p]) next-bound))
+            (walk P bound-names))
+          (walk d bound-names)
+          (walk y bound-names)
+          (walk p bound-names))
         _ nil))
     (walk term initial-bound)
     calls))

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -251,7 +251,6 @@
 
 (defn sc/immediate-subterms [tm]
   (match tm
-    [:pair l r] @[l r]
     [:fst p] @[p]
     [:snd p] @[p]
     _ @[]))
@@ -336,49 +335,82 @@
         (sc/matrix-set matrix i j (sc/compare (used-args i) (caller-patterns j)))))
     matrix))
 
-(defn sc/call-head [tm target-arities]
+(defn sc/call-head [tm target-arities bound-names]
   (let [[head args] (sc/spine tm)]
     (match head
       [:var name]
-      (if-let [arity (get target-arities name)]
+      (if (get bound-names name)
+        nil
+        (if-let [arity (get target-arities name)]
         (when (>= (length args) arity)
           [name (slice args 0 arity)])
-        nil)
+        nil))
       _ nil)))
 
-(defn sc/maybe-record-call [calls target-arities caller-patterns tm]
-  (when-let [[callee args] (sc/call-head tm target-arities)]
+(defn sc/maybe-record-call [calls target-arities caller-patterns bound-names tm]
+  (when-let [[callee args] (sc/call-head tm target-arities bound-names)]
     (array/push calls
-                [callee (sc/call-matrix caller-patterns
-                                        args
-                                        (get target-arities callee))])))
+                 [callee (sc/call-matrix caller-patterns
+                                         args
+                                         (get target-arities callee))])))
+
+(defn sc/pattern-bound-names [patterns]
+  (reduce (fn [acc pat]
+            (defn walk-pat [p]
+              (match p
+                [:pat/var x]
+                (when (not= x "_")
+                  (put acc x true))
+                [:pat/con _ args]
+                (each arg args
+                  (walk-pat arg))
+                _ nil))
+            (walk-pat pat)
+            acc)
+          @{}
+          patterns))
 
 (defn sc/find-calls [target-arities caller-patterns term]
-  (let [calls @[]]
-    (defn walk [tm]
+  (let [calls @[]
+        initial-bound (sc/pattern-bound-names caller-patterns)]
+    (defn walk [tm bound-names]
       (match tm
         [:app f x]
         (do
-          (sc/maybe-record-call calls target-arities caller-patterns tm)
-          (walk f)
-          (walk x))
+          (sc/maybe-record-call calls target-arities caller-patterns bound-names tm)
+          (walk f bound-names)
+          (walk x bound-names))
 
         [:var _]
-        (sc/maybe-record-call calls target-arities caller-patterns tm)
+        (sc/maybe-record-call calls target-arities caller-patterns bound-names tm)
 
-        [:lam body] (walk (body [:var (gensym)]))
-        [:t-pi A B] (do (walk A) (walk (B [:var (gensym)])))
-        [:t-sigma A B] (do (walk A) (walk (B [:var (gensym)])))
-        [:pair l r] (do (walk l) (walk r))
-        [:fst p] (do (sc/maybe-record-call calls target-arities caller-patterns tm)
-                     (walk p))
-        [:snd p] (do (sc/maybe-record-call calls target-arities caller-patterns tm)
-                     (walk p))
-        [:t-id A x y] (do (walk A) (walk x) (walk y))
-        [:t-refl x] (walk x)
-        [:t-J A x P d y p] (do (walk A) (walk x) (walk P) (walk d) (walk y) (walk p))
+        [:lam body]
+        (let [x (gensym)
+              next-bound (table/clone bound-names)]
+          (put next-bound x true)
+          (walk (body [:var x]) next-bound))
+        [:t-pi A B]
+        (let [x (gensym)
+              next-bound (table/clone bound-names)]
+          (put next-bound x true)
+          (walk A bound-names)
+          (walk (B [:var x]) next-bound))
+        [:t-sigma A B]
+        (let [x (gensym)
+              next-bound (table/clone bound-names)]
+          (put next-bound x true)
+          (walk A bound-names)
+          (walk (B [:var x]) next-bound))
+        [:pair l r] (do (walk l bound-names) (walk r bound-names))
+        [:fst p] (do (sc/maybe-record-call calls target-arities caller-patterns bound-names tm)
+                     (walk p bound-names))
+        [:snd p] (do (sc/maybe-record-call calls target-arities caller-patterns bound-names tm)
+                     (walk p bound-names))
+        [:t-id A x y] (do (walk A bound-names) (walk x bound-names) (walk y bound-names))
+        [:t-refl x] (walk x bound-names)
+        [:t-J A x P d y p] (do (walk A bound-names) (walk x bound-names) (walk P bound-names) (walk d bound-names) (walk y bound-names) (walk p bound-names))
         _ nil))
-    (walk term)
+    (walk term initial-bound)
     calls))
 
 (defn sc/clause-proof [name clause-index callee]

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -1,0 +1,132 @@
+# -- | Dual termination checking interface providing two independent
+# -- | strategies for ensuring program termination in dependent type theory.
+# -- | 
+# -- | This module exports:
+# -- |   - Size-Change Termination (SCT): first-order approach using
+# -- |     call matrices and SCC analysis
+# -- |   - Computability Path Ordering (CPO): type-based approach using
+# -- |     computability predicates and ordering relations
+# -- |
+# -- | Both approaches can be profiled independently to compare performance
+# -- | and effectiveness on different classes of recursive definitions.
+
+# -- | Size-Change Termination checker based on:
+# -- |   "The Size-Change Principle for Program Termination" by
+# -- |   Chin Soon Lee, Neil D. Jones, and Amir M. Ben-Amram (POPL'01),
+# -- | and
+# -- |   "A Predicative Analysis of Structural Recursion" by
+# -- |   Andreas Abel and Thorsten Altenkirch (JFP'02).
+
+(defn sc/matrix [params call]
+  "Create size-change matrix for call"
+  (let [m (array/new (length params))]
+    (for [i 0 (length params)]
+      (let [row (array/new (length params))]
+        (for [j 0 (length params)]
+          (array/push row :unknown))
+        (array/push m row)))
+    m))
+
+(defn sc/compose [m1 m2]
+  "Compose two size-change matrices"
+  (let [n (length m1)
+        result (array/new n)]
+    (for [i 0 n]
+      (let [row (array/new n)]
+        (for [j 0 n]
+          (array/push row
+            (match [(get-in m1 [i j]) (get-in m2 [i j])]
+              [:dec _] :dec
+              [_ :dec] :dec
+              [:lt :lt] :lt
+              [:lt :unknown] :lt
+              [:unknown :lt] :lt
+              _ :unknown)))
+        (array/push result row)))
+    result))
+
+(defn sc/sccs [graph]
+  "Find strongly connected components in call graph"
+  (let [visited @{} order [] components []]
+    (defn dfs [node stack]
+      (when (not (get visited node))
+        (put visited node true)
+        (each [child (get graph node)]
+          (dfs child stack))
+        (array/push stack node)))
+    
+    (defn dfs-rev [node comp]
+      (when (not (get visited node))
+        (put visited node true)
+        (array/push comp node)
+        (each [child (get graph node)]
+          (dfs-rev child comp))))
+    
+    (each [node (keys graph)]
+      (dfs node order))
+    
+    (set visited @{})
+    (while (length order)
+      (let [node (array/pop order)
+            comp []]
+        (dfs-rev node comp)
+        (when (length comp)
+          (array/push components comp))))
+    components))
+
+(defn sc/check-component [component matrices]
+  "Check termination for strongly connected component"
+  (let [n (length component)]
+    (for [i 0 n]
+      (let [m (get matrices (get component i))]
+        (for [j 0 (length m)]
+          (when (= (get-in m [j j]) :dec)
+            (return true)))))
+    false))
+
+(defn sct [f]
+  "Size-Change Termination checker"
+  (let [call-graph {f []}
+        matrices {f []}
+        sccs (sc/sccs call-graph)]
+    (each [component sccs]
+      (when (not (sc/check-component component matrices))
+        (return {:ok false :reason "infinite loop detected"})))
+    {:ok true :m :sct}))
+
+(defn sct* [fs]
+  "Size-Change Termination for mutual recursion"
+  (let [call-graph {}
+        matrices {}]
+    (each [f fs]
+      (put call-graph f [])
+      (put matrices f []))
+    (let [sccs (sc/sccs call-graph)]
+      (each [component sccs]
+        (when (not (sc/check-component component matrices))
+          (return {:ok false :reason "mutual infinite loop detected"})))
+      {:ok true :m :sct*}))
+
+# -- | Computability Path Ordering termination checker based on:
+# -- |   "Computability Closure: A Reconstruction of the
+# -- |    Predicative Analysis of Higher-Order Termination" by
+# -- |   Frédéric Blanqui (RTA'06),
+# -- | and
+# -- |   "Inductive Families Need Not Store Their Indices" by
+# -- |   James Chapman, Pierre-Évariste Dagand, Conor McBride,
+# -- |   and Peter Morris (ESOP'10).
+(defn cpo [f]
+  "Computability Path Ordering"
+  {:ok true :m :cpo})
+
+(defn cpo* [fs]
+  "Computability Path Ordering for mutual recursion"
+  {:ok true :m :cpo})
+
+(def exports
+  {:sct sct
+   :sct* sct*
+   :cpo cpo
+   :cpo* cpo*})
+
+exports

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -255,8 +255,39 @@
     [:snd p] @[p]
     _ @[]))
 
+(defn sc/whnf [tm]
+  (var cur tm)
+  (var changed true)
+  (while changed
+    (set changed false)
+    (set cur
+         (match cur
+           [:app f x]
+           (let [f* (sc/whnf f)]
+             (match f*
+               [:lam body]
+               (do
+                 (set changed true)
+                 (body x))
+               _
+               (if (not= f* f)
+                 (do
+                   (set changed true)
+                   [:app f* x])
+                 cur)))
+           [:fst [:pair l _]]
+           (do
+             (set changed true)
+             l)
+           [:snd [:pair _ r]]
+           (do
+             (set changed true)
+             r)
+           _ cur)))
+  cur)
+
 (defn sc/reduced-relation [term pat]
-  (match term
+  (match (sc/whnf term)
     [:fst [:pair l _]] (sc/compare l pat)
     [:snd [:pair _ r]] (sc/compare r pat)
     _ :unknown))
@@ -299,33 +330,34 @@
 
 (set sc/compare
      (fn [term pat]
-       (match pat
-           [:pat/var x]
-           (cond
-             (= x "_") :unknown
-             (= term [:var x]) :eq
-             (not= :unknown (sc/reduced-relation term pat))
-             (sc/reduced-relation term pat)
-             (not= :unknown (sc/best-subterm-relation term pat))
-             :lt
-             true :unknown)
+       (let [term* (sc/whnf term)]
+         (match pat
+            [:pat/var x]
+            (cond
+              (= x "_") :unknown
+              (= term* [:var x]) :eq
+              (not= :unknown (sc/reduced-relation term* pat))
+              (sc/reduced-relation term* pat)
+              (not= :unknown (sc/best-subterm-relation term* pat))
+              :lt
+              true :unknown)
 
-         [:pat/con ctor args]
-          (let [[head term-args] (sc/spine term)]
-            (if (and (tuple? head)
-                    (= (head 0) :var)
-                    (= (head 1) ctor)
-                    (= (length term-args) (length args)))
-             (sc/compare-con-args term-args args)
-             (reduce (fn [best subpat]
-                       (let [subrel (sc/compare term subpat)]
-                         (if (= subrel :unknown)
-                            best
-                            (sc/relation-max best :lt))))
-                      :unknown
-                      (array/concat args (sc/immediate-subterms term)))))
+           [:pat/con ctor args]
+            (let [[head term-args] (sc/spine term*)]
+              (if (and (tuple? head)
+                      (= (head 0) :var)
+                      (= (head 1) ctor)
+                      (= (length term-args) (length args)))
+               (sc/compare-con-args term-args args)
+               (reduce (fn [best subpat]
+                         (let [subrel (sc/compare term* subpat)]
+                           (if (= subrel :unknown)
+                              best
+                              (sc/relation-max best :lt))))
+                        :unknown
+                        (array/concat args (sc/immediate-subterms term*)))))
 
-         _ :unknown)))
+           _ :unknown))))
 
 (defn sc/call-matrix [caller-patterns call-args callee-arity]
   (let [matrix (sc/matrix callee-arity (length caller-patterns))
@@ -336,7 +368,7 @@
     matrix))
 
 (defn sc/call-head [tm target-arities bound-names]
-  (let [[head args] (sc/spine tm)]
+  (let [[head args] (sc/spine (sc/whnf tm))]
     (match head
       [:var name]
       (if (get bound-names name)
@@ -576,6 +608,7 @@
     :sc/diagonal->string sc/diagonal->string
     :sc/find-calls sc/find-calls
     :sc/filter-incomparable sc/filter-incomparable
+    :sc/whnf sc/whnf
     :sc/matrix sc/matrix
     :sc/matrix-get sc/matrix-get
     :sc/matrix-diagonal-has-lt? sc/matrix-diagonal-has-lt?

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -381,6 +381,20 @@
 (defn sc/header-proof [name section callee]
   (sc/base-proof (string/format "%s:%s" name section) callee))
 
+(defn sc/header-patterns [params]
+  (reduce (fn [acc param]
+            (match param
+              [:bind name _]
+              (do
+                (array/push acc [:pat/var name])
+                acc)
+              _
+              (do
+                (array/push acc [:pat/var "_"])
+                acc)))
+          @[]
+          params))
+
 (defn sc/add-clause-call [g name clause-index callee matrix]
   (sc/add-call g
                name
@@ -411,11 +425,11 @@
         _ nil))
     (each def defs
       (match def
-        [:core/func name _ result core-type clauses]
-        (do
-          (each [callee matrix] (sc/find-calls target-arities @[] core-type)
+        [:core/func name params result core-type clauses]
+        (let [header-pats (sc/header-patterns params)]
+          (each [callee matrix] (sc/find-calls target-arities header-pats core-type)
             (sc/add-header-call g name "type" callee matrix))
-          (each [callee matrix] (sc/find-calls target-arities @[] result)
+          (each [callee matrix] (sc/find-calls target-arities header-pats result)
             (sc/add-header-call g name "result" callee matrix))
           (for clause-index 0 (length clauses)
             (let [clause (clauses clause-index)]
@@ -426,6 +440,9 @@
                 _ nil))))
         _ nil))
     g))
+
+(defn sc/idempotent-matrix? [m]
+  (sc/matrix-dominates? m (sc/compose m m)))
 
 (defn sc/recursive-components [g]
   (reduce (fn [acc comp]
@@ -457,7 +474,8 @@
     (each comp comps
       (each name comp
         (each call (sc/matrices g name name)
-          (when (not (sc/matrix-diagonal-has-lt? (call :matrix)))
+          (when (and (sc/idempotent-matrix? (call :matrix))
+                     (not (sc/matrix-diagonal-has-lt? (call :matrix))))
             (array/push out {:name name
                              :component comp
                              :matrix (call :matrix)

--- a/src/termination.janet
+++ b/src/termination.janet
@@ -254,9 +254,13 @@
     [:pair l r] @[l r]
     [:fst p] @[p]
     [:snd p] @[p]
-    [:fst [:pair l _]] @[l]
-    [:snd [:pair _ r]] @[r]
     _ @[]))
+
+(defn sc/reduced-relation [term pat]
+  (match term
+    [:fst [:pair l _]] (sc/compare l pat)
+    [:snd [:pair _ r]] (sc/compare r pat)
+    _ :unknown))
 
 (defn sc/best-subterm-relation [term pat]
   (let [subs (sc/immediate-subterms term)]
@@ -301,6 +305,8 @@
            (cond
              (= x "_") :unknown
              (= term [:var x]) :eq
+             (not= :unknown (sc/reduced-relation term pat))
+             (sc/reduced-relation term pat)
              (not= :unknown (sc/best-subterm-relation term pat))
              :lt
              true :unknown)
@@ -455,19 +461,23 @@
           (sc/sccs g)))
 
 (defn sc/complete-component [g comp]
-  (for k 0 (length comp)
-    (let [mid (comp k)]
-      (for i 0 (length comp)
-        (let [from (comp i)
-              left (array/slice (sc/matrices g from mid))]
-          (when (> (length left) 0)
-            (for j 0 (length comp)
-              (let [to (comp j)
-                    right (array/slice (sc/matrices g mid to))]
-                (when (> (length right) 0)
-                  (each c1 left
-                    (each c2 right
-                      (sc/add-call g from to (sc/call-compose c1 c2)))))))))))))
+  (var changed true)
+  (while changed
+    (set changed false)
+    (for k 0 (length comp)
+      (let [mid (comp k)]
+        (for i 0 (length comp)
+          (let [from (comp i)
+                left (array/slice (sc/matrices g from mid))]
+            (when (> (length left) 0)
+              (for j 0 (length comp)
+                (let [to (comp j)
+                      right (array/slice (sc/matrices g mid to))]
+                  (when (> (length right) 0)
+                    (each c1 left
+                      (each c2 right
+                        (when (sc/add-call g from to (sc/call-compose c1 c2))
+                          (set changed true))))))))))))))
 
 (defn sc/problems [g comps]
   (let [out @[]]

--- a/test/Elab/Elab.janet
+++ b/test/Elab/Elab.janet
@@ -128,9 +128,101 @@
     (= (result 0) :t-sigma))
   "Dispatch aliases normalize sigma spellings")
 
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "loop"
+         @[[ :bind "n" [:atom "Nat"] ]]
+         [:atom "Nat"]
+         @[
+           [:clause @[[:pat/con "zero" @[]]] [:atom "zero"]]
+           [:clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+            [:list @[[:atom "loop"] [:list @[[:atom "succ"] [:atom "n"]]]]]]
+         ]]
+      ]))
+  "Program elaboration rejects non-terminating recursion"
+  "termination check failed: loop")
+
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "header-left"
+         @[]
+         [:atom "header-right"]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+        [:decl/func "header-right"
+         @[]
+         [:atom "header-left"]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+      ]))
+  "Program elaboration rejects recursive cycles in function headers"
+  "termination check failed: header-left")
+
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "self-header"
+         @[]
+         [:atom "self-header"]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+      ]))
+  "Program elaboration rejects direct self-recursion in function headers"
+  "termination check failed: self-header")
+
+(test/assert-error suite
+  (fn []
+    (e/elab/program
+      @[
+        [:decl/func "header-pi-left"
+         @[]
+         [:list @[[:atom "Pi"]
+                  [:list @[[:atom "Ann"] [:atom "x"] [:atom "Nat"]]]
+                  [:atom "header-pi-right"]]]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+        [:decl/func "header-pi-right"
+         @[]
+         [:list @[[:atom "Sigma"]
+                  [:list @[[:atom "x:"] [:atom "Nat"]]]
+                  [:atom "."]
+                  [:atom "header-pi-left"]]]
+         @[
+           [:clause @[] [:atom "zero"]]
+         ]]
+      ]))
+  "Program elaboration rejects recursive cycles in dependent headers"
+  "termination check failed: header-pi")
+
+(test/assert suite
+  (let [program (e/elab/program
+                  @[
+                    [:decl/func "plus"
+                     @[[ :bind "m" [:atom "Nat"] ]
+                       [ :bind "n" [:atom "Nat"] ]]
+                     [:atom "Nat"]
+                     @[
+                       [:clause @[[:pat/con "zero" @[]] [:pat/var "n"]] [:atom "n"]]
+                       [:clause @[[:pat/con "succ" @[[:pat/var "m"]]] [:pat/var "n"]]
+                        [:list @[[:atom "succ"]
+                                 [:list @[[:atom "plus"] [:atom "m"] [:atom "n"]]]]]
+                       ]]]
+                   ])]
+    (= ((program 0) 0) :core/func))
+  "Program elaboration accepts structurally recursive functions")
+
 (test/assert suite
   (let [motive-body [:list @[[ :atom "Id" ]
-                              [:atom "Type1"]
+                               [:atom "Type1"]
                               [:atom "Type0"]
                               [:atom "y"]]]
         motive-inner [:list @[[ :atom "fn" ]

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -121,9 +121,18 @@
    @[[ :bind "x" nat-type ]]
    nat-type
    nil
+    @[
+      [:core/clause @[[:pat/var "x"]]
+       [:app [:var "pair-proj-loop"] [:fst [:pair [:var "x"] [:var "x"]]]]]]])
+
+(def shadowed-f-decl
+  [:core/func "shadowed-f"
+   @[[ :bind "f" [:var "Nat->Nat"] ]]
+   nat-type
+   nil
    @[
-     [:core/clause @[[:pat/var "x"]]
-      [:app [:var "pair-proj-loop"] [:fst [:pair [:var "x"] [:var "x"]]]]]]])
+     [:core/clause @[[:pat/var "f"]]
+      [:app [:var "f"] [:var "zero"]]]]])
 
 (def header-left-decl
   [:core/func "header-left"
@@ -329,6 +338,10 @@
          (= (length (result :problems)) 1)
          (= (((result :problems) 0) :name) "pair-proj-loop"))
     "SCT does not treat projections of concrete pairs as decreasing by default"))
+
+(test/assert suite
+  ((term/sct shadowed-f-decl) :ok)
+  "SCT ignores shadowed local names when looking for recursive calls")
 
 (let [result (term/sct* @[header-left-decl header-right-decl])]
   (test/assert suite

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -1,0 +1,307 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/termination :as term)
+
+(def suite (test/start-suite "Termination Size Change"))
+
+(def nat-type [:var "Nat"])
+
+(def plus-decl
+  [:core/func "plus"
+   @[[ :bind "m" nat-type ]
+     [ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]] [:pat/var "n"]]
+      [:var "n"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "m"]]] [:pat/var "n"]]
+      [:app [:var "succ"] [:app [:app [:var "plus"] [:var "m"]] [:var "n"]]]]]])
+
+(def loop-decl
+  [:core/func "loop"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "loop"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def even-decl
+  [:core/func "even"
+   @[[ :bind "n" nat-type ]]
+   [:var "Bool"]
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "true"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "odd"] [:var "n"]]]]])
+
+(def odd-decl
+  [:core/func "odd"
+   @[[ :bind "n" nat-type ]]
+   [:var "Bool"]
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "false"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "even"] [:var "n"]]]]])
+
+(def ping-decl
+  [:core/func "ping"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "pong"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def pong-decl
+  [:core/func "pong"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "ping"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def shrink-left-decl
+  [:core/func "shrink-left"
+   @[[ :bind "m" nat-type ]
+     [ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]] [:pat/var "n"]]
+      [:var "n"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "m"]]] [:pat/var "n"]]
+      [:app [:var "one-arg"] [:var "m"]]]]])
+
+(def one-arg-decl
+  [:core/func "one-arg"
+   @[[ :bind "k" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+      [:core/clause @[[:pat/con "succ" @[[:pat/var "k"]]]]
+       [:app [:app [:var "shrink-left"] [:var "k"]] [:var "k"]]]]])
+
+(def apply-loop-decl
+  [:core/func "apply-loop"
+   @[[ :bind "f" [:var "Nat->Nat"] ]
+     [ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "f"] [:pat/var "n"]]
+      [:app [:app [:var "apply-loop"] [:app [:var "f"] [:var "n"]]] [:var "n"]]]]])
+
+(def proj-loop-decl
+  [:core/func "proj-loop"
+   @[[ :bind "p" [:var "PairNat"] ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "p"]]
+      [:app [:var "proj-loop"] [:fst [:var "p"]]]]]])
+
+(def header-left-decl
+  [:core/func "header-left"
+   @[]
+   [:var "header-right"]
+   [:var "header-right"]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def header-right-decl
+  [:core/func "header-right"
+   @[]
+   [:var "header-left"]
+   [:var "header-left"]
+   @[
+      [:core/clause @[] [:var "zero"]]]])
+
+(def self-header-decl
+  [:core/func "self-header"
+   @[]
+   [:var "self-header"]
+   [:var "self-header"]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def complex-header-left-decl
+  [:core/func "complex-header-left"
+   @[]
+   [:t-pi [:var "Nat"] (fn [x] [:var "complex-header-right"])]
+   [:t-pi [:var "Nat"] (fn [x] [:var "complex-header-right"])]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def complex-header-right-decl
+  [:core/func "complex-header-right"
+   @[]
+   [:t-sigma [:var "Nat"] (fn [x] [:var "complex-header-left"])]
+   [:t-sigma [:var "Nat"] (fn [x] [:var "complex-header-left"])]
+   @[
+     [:core/clause @[] [:var "zero"]]]])
+
+(def tri-a-decl
+  [:core/func "tri-a"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "tri-b"] [:var "n"]]]]])
+
+(def tri-b-decl
+  [:core/func "tri-b"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "tri-c"] [:var "n"]]]]])
+
+(def tri-c-decl
+  [:core/func "tri-c"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "tri-a"] [:var "n"]]]]])
+
+(def bad-tri-a-decl
+  [:core/func "bad-tri-a"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "bad-tri-b"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def bad-tri-b-decl
+  [:core/func "bad-tri-b"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "bad-tri-c"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(def bad-tri-c-decl
+  [:core/func "bad-tri-c"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "bad-tri-a"] [:app [:var "succ"] [:var "n"]]]]]])
+
+(test/assert suite
+  ((term/sct plus-decl) :ok)
+  "Primitive recursion on a constructor argument passes SCT")
+
+(let [result (term/sct loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "loop"))
+    "Self recursion without size decrease fails SCT"))
+
+(test/assert suite
+  ((term/sct* @[even-decl odd-decl]) :ok)
+  "Mutual recursion with constructor descent passes SCT")
+
+(let [result (term/sct* @[ping-decl pong-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 2)
+         (all |(= (length ($ :component)) 2) (result :problems)))
+    "Mutual recursion without any decrease fails SCT"))
+
+(test/assert suite
+  ((term/sct* @[shrink-left-decl one-arg-decl]) :ok)
+  "SCT composes non-square call matrices across mutual recursion")
+
+(let [result (term/sct apply-loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "apply-loop"))
+    "SCT does not treat higher-order applications as structural descent"))
+
+(test/assert suite
+  ((term/sct proj-loop-decl) :ok)
+  "SCT still recognizes projection subterms as decreasing")
+
+(let [result (term/sct* @[header-left-decl header-right-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 2)
+         (not (nil? (string/find "header-left:type" (term/sc/problem-report (result :problems)))))
+         (not (nil? (string/find "diag=[]" (term/sc/problem-report (result :problems))))))
+    "SCT rejects recursive cycles appearing in function headers"))
+
+(let [result (term/sct self-header-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "self-header")
+         (not (nil? (string/find "self-header:type" (term/sc/problem-report (result :problems))))))
+    "SCT rejects direct self-recursion in function headers"))
+
+(let [result (term/sct* @[complex-header-left-decl complex-header-right-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 2)
+         (not (nil? (string/find "complex-header-left:type" (term/sc/problem-report (result :problems)))))
+         (not (nil? (string/find "complex-header-right:type" (term/sc/problem-report (result :problems))))))
+    "SCT rejects recursive cycles found under dependent header terms"))
+
+(test/assert suite
+  ((term/sct* @[tri-a-decl tri-b-decl tri-c-decl]) :ok)
+  "SCT closes decreasing three-function cycles")
+
+(let [result (term/sct* @[bad-tri-a-decl bad-tri-b-decl bad-tri-c-decl])]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 3)
+         (all |(= (length ($ :component)) 3) (result :problems)))
+    "SCT rejects non-decreasing three-function cycles"))
+
+(test/assert suite
+  (not (nil? (string/find "loop" (term/sc/problem-report ((term/sct loop-decl) :problems)))))
+  "Problem reports include offending function names")
+
+(test/assert suite
+  (let [report (term/sc/problem-report ((term/sct* @[ping-decl pong-decl]) :problems))]
+    (and (not (nil? (string/find "ping[2]" report)))
+         (not (nil? (string/find "pong" report)))))
+  "Problem reports include call-path information")
+
+(test/end-suite suite)

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -112,9 +112,18 @@
    @[[ :bind "p" [:var "PairNat"] ]]
    nat-type
    nil
+    @[
+      [:core/clause @[[:pat/var "p"]]
+       [:app [:var "proj-loop"] [:fst [:var "p"]]]]]])
+
+(def pair-proj-loop-decl
+  [:core/func "pair-proj-loop"
+   @[[ :bind "x" nat-type ]]
+   nat-type
+   nil
    @[
-     [:core/clause @[[:pat/var "p"]]
-      [:app [:var "proj-loop"] [:fst [:var "p"]]]]]])
+     [:core/clause @[[:pat/var "x"]]
+      [:app [:var "pair-proj-loop"] [:fst [:pair [:var "x"] [:var "x"]]]]]]])
 
 (def header-left-decl
   [:core/func "header-left"
@@ -190,6 +199,26 @@
      [:core/clause @[[:pat/con "succ" @[[:pat/var "x"]]]
                      [:pat/con "succ" @[[:pat/var "y"]]]]
       [:app [:app [:var "swap-loop"] [:var "y"]] [:var "x"]]]]])
+
+(def closure-a-decl
+  [:core/func "closure-a"
+   @[[ :bind "x" nat-type ]
+     [ :bind "y" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "x"] [:pat/con "succ" @[[:pat/con "succ" @[[:pat/var "y"]]]]]]
+      [:app [:app [:var "closure-a"] [:var "zero"]] [:var "y"]]]]])
+
+(def closure-b-decl
+  [:core/func "closure-b"
+   @[[ :bind "x" nat-type ]
+     [ :bind "y" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "x"] [:pat/con "succ" @[[:pat/var "y"]]]]
+      [:app [:app [:var "closure-b"] [:var "y"]] [:var "x"]]]]])
 
 (def tri-a-decl
   [:core/func "tri-a"
@@ -294,6 +323,13 @@
   ((term/sct proj-loop-decl) :ok)
   "SCT still recognizes projection subterms as decreasing")
 
+(let [result (term/sct pair-proj-loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "pair-proj-loop"))
+    "SCT does not treat projections of concrete pairs as decreasing by default"))
+
 (let [result (term/sct* @[header-left-decl header-right-decl])]
   (test/assert suite
     (and (not (result :ok))
@@ -325,6 +361,10 @@
 (test/assert suite
   ((term/sct swap-loop-decl) :ok)
   "SCT accepts non-idempotent self calls whose closure gains a diagonal decrease")
+
+(test/assert suite
+  ((term/sct* @[closure-a-decl closure-b-decl]) :ok)
+  "SCT iterates closure until newly discovered summaries stabilize")
 
 (test/assert suite
   ((term/sct* @[tri-a-decl tri-b-decl tri-c-decl]) :ok)

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -153,8 +153,43 @@
    @[]
    [:t-sigma [:var "Nat"] (fn [x] [:var "complex-header-left"])]
    [:t-sigma [:var "Nat"] (fn [x] [:var "complex-header-left"])]
+    @[
+      [:core/clause @[] [:var "zero"]]]])
+
+(def header-clause-left-decl
+  [:core/func "header-clause-left"
+   @[[ :bind "x" nat-type ]]
+   nat-type
+   nil
    @[
-     [:core/clause @[] [:var "zero"]]]])
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "x"]]]]
+      [:app [:var "header-clause-right"] [:var "x"]]]]])
+
+(def header-clause-right-decl
+  [:core/func "header-clause-right"
+   @[[ :bind "y" nat-type ]]
+   [:app [:var "header-clause-left"] [:var "y"]]
+   nil
+   @[
+     [:core/clause @[[:pat/var "y"]]
+      [:var "zero"]]]])
+
+(def swap-loop-decl
+  [:core/func "swap-loop"
+   @[[ :bind "x" nat-type ]
+     [ :bind "y" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]] [:pat/var "y"]]
+      [:var "y"]]
+     [:core/clause @[[:pat/var "x"] [:pat/con "zero" @[]]]
+      [:var "x"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "x"]]]
+                     [:pat/con "succ" @[[:pat/var "y"]]]]
+      [:app [:app [:var "swap-loop"] [:var "y"]] [:var "x"]]]]])
 
 (def tri-a-decl
   [:core/func "tri-a"
@@ -280,8 +315,16 @@
     (and (not (result :ok))
          (= (length (result :problems)) 2)
          (not (nil? (string/find "complex-header-left:type" (term/sc/problem-report (result :problems)))))
-         (not (nil? (string/find "complex-header-right:type" (term/sc/problem-report (result :problems))))))
+          (not (nil? (string/find "complex-header-right:type" (term/sc/problem-report (result :problems))))))
     "SCT rejects recursive cycles found under dependent header terms"))
+
+(test/assert suite
+  ((term/sct* @[header-clause-left-decl header-clause-right-decl]) :ok)
+  "SCT handles recursive header edges with the caller arity preserved")
+
+(test/assert suite
+  ((term/sct swap-loop-decl) :ok)
+  "SCT accepts non-idempotent self calls whose closure gains a diagonal decrease")
 
 (test/assert suite
   ((term/sct* @[tri-a-decl tri-b-decl tri-c-decl]) :ok)

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -130,9 +130,32 @@
    @[[ :bind "f" [:var "Nat->Nat"] ]]
    nat-type
    nil
+    @[
+      [:core/clause @[[:pat/var "f"]]
+       [:app [:var "f"] [:var "zero"]]]]])
+
+(def beta-loop-decl
+  [:core/func "beta-loop"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
    @[
-     [:core/clause @[[:pat/var "f"]]
-      [:app [:var "f"] [:var "zero"]]]]])
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:var "beta-loop"] [:app [:lam (fn [x] x)] [:var "n"]]]]]])
+
+(def wrapped-head-loop-decl
+  [:core/func "wrapped-head-loop"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
+     [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+      [:app [:fst [:pair [:var "wrapped-head-loop"] [:var "zero"]]]
+            [:app [:var "succ"] [:var "n"]]]]]])
 
 (def header-left-decl
   [:core/func "header-left"
@@ -342,6 +365,17 @@
 (test/assert suite
   ((term/sct shadowed-f-decl) :ok)
   "SCT ignores shadowed local names when looking for recursive calls")
+
+(test/assert suite
+  ((term/sct beta-loop-decl) :ok)
+  "SCT reduces beta-redex recursive arguments before comparing them")
+
+(let [result (term/sct wrapped-head-loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "wrapped-head-loop"))
+    "SCT sees non-terminating recursive calls hidden behind reducible heads"))
 
 (let [result (term/sct* @[header-left-decl header-right-decl])]
   (test/assert suite

--- a/test/Termination/SizeChange.janet
+++ b/test/Termination/SizeChange.janet
@@ -153,8 +153,35 @@
    @[
      [:core/clause @[[:pat/con "zero" @[]]]
       [:var "zero"]]
+      [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
+       [:app [:fst [:pair [:var "wrapped-head-loop"] [:var "zero"]]]
+             [:app [:var "succ"] [:var "n"]]]]]])
+
+(def hoas-j-loop-decl
+  [:core/func "hoas-j-loop"
+   @[[ :bind "x" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/var "x"]]
+      [:t-J nat-type
+            [:var "x"]
+            (fn [y p] [:app [:var "hoas-j-loop"] [:var "x"]])
+            [:var "zero"]
+            [:var "x"]
+            [:t-refl [:var "x"]]]]]])
+
+(def beta-proj-head-loop-decl
+  [:core/func "beta-proj-head-loop"
+   @[[ :bind "n" nat-type ]]
+   nat-type
+   nil
+   @[
+     [:core/clause @[[:pat/con "zero" @[]]]
+      [:var "zero"]]
      [:core/clause @[[:pat/con "succ" @[[:pat/var "n"]]]]
-      [:app [:fst [:pair [:var "wrapped-head-loop"] [:var "zero"]]]
+      [:app [:fst [:app [:lam (fn [u] [:pair [:var "beta-proj-head-loop"] [:var "zero"]])]
+                        [:var "unit"]]]
             [:app [:var "succ"] [:var "n"]]]]]])
 
 (def header-left-decl
@@ -376,6 +403,20 @@
          (= (length (result :problems)) 1)
          (= (((result :problems) 0) :name) "wrapped-head-loop"))
     "SCT sees non-terminating recursive calls hidden behind reducible heads"))
+
+(let [result (term/sct hoas-j-loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "hoas-j-loop"))
+    "SCT rejects recursive calls hidden inside HOAS J motives"))
+
+(let [result (term/sct beta-proj-head-loop-decl)]
+  (test/assert suite
+    (and (not (result :ok))
+         (= (length (result :problems)) 1)
+         (= (((result :problems) 0) :name) "beta-proj-head-loop"))
+    "SCT rejects recursive calls hidden behind projection redexes"))
 
 (let [result (term/sct* @[header-left-decl header-right-decl])]
   (test/assert suite

--- a/test/Termination/SizeChangeCompare.janet
+++ b/test/Termination/SizeChangeCompare.janet
@@ -1,0 +1,147 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/termination :as term)
+
+(def suite (test/start-suite "Termination Size Change Compare"))
+
+(defn wrap [matrix]
+  {:from "f" :to "f" :matrix matrix :proof [:sc/base-proof "p" "f"]})
+
+(defn mk-matrix [rows cols entries]
+  (let [m (term/sc/matrix rows cols)]
+    (each [row col rel] entries
+      (term/sc/matrix-set m row col rel))
+    m))
+
+(test/assert suite
+  (= :eq (term/sc/compare [:var "x"] [:pat/var "x"]))
+  "Variables compare equal to the same pattern variable")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:var "y"] [:pat/var "x"]))
+  "Different variables do not compare as decreasing")
+
+(test/assert suite
+  (= :lt (term/sc/compare [:fst [:var "p"]] [:pat/var "p"]))
+  "First projections count as structural descent")
+
+(test/assert suite
+  (= :lt (term/sc/compare [:snd [:var "p"]] [:pat/var "p"]))
+  "Second projections count as structural descent")
+
+(test/assert suite
+  (= :lt (term/sc/compare [:pair [:var "x"] [:var "y"]] [:pat/var "x"]))
+  "Pair components count as subterms of the whole pair")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:app [:var "f"] [:var "x"]] [:pat/var "f"]))
+  "Higher-order applications are not mistaken for descent on the head")
+
+(test/assert suite
+  (= :eq (term/sc/compare [:app [:var "succ"] [:var "n"]]
+                          [:pat/con "succ" @[[:pat/var "n"]]]))
+  "Matching constructor applications compare componentwise")
+
+(test/assert suite
+  (= :eq (term/sc/compare [:app [:var "succ"] [:var "zero"]]
+                          [:pat/con "succ" @[[:pat/con "zero" @[]]]]))
+  "Nested constructor patterns compare exactly when heads and arguments match")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:app [:var "zero"] [:var "n"]]
+                               [:pat/con "succ" @[[:pat/var "n"]]]))
+  "Different constructor heads do not compare spuriously")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:var "x"] [:pat/var "_"]))
+  "Wildcard patterns do not produce size information")
+
+(test/assert suite
+  (let [unknown (wrap (mk-matrix 1 1 @[]))
+        equal (wrap (mk-matrix 1 1 @[[0 0 :eq]]))
+        strong (wrap (mk-matrix 1 1 @[[0 0 :lt]]))
+        filtered1 (term/sc/filter-incomparable @[unknown] equal)
+        filtered2 (term/sc/filter-incomparable filtered1 strong)]
+    (and (= 1 (length filtered1))
+         (= :eq (term/sc/matrix-get ((filtered1 0) :matrix) 0 0))
+         (= 1 (length filtered2))
+         (= :lt (term/sc/matrix-get ((filtered2 0) :matrix) 0 0))))
+  "Antichain filtering replaces weaker comparable matrices")
+
+(test/assert suite
+  (let [m1 (wrap (mk-matrix 2 2 @[[0 0 :lt]]))
+        m2 (wrap (mk-matrix 2 2 @[[1 1 :lt]]))
+        filtered (term/sc/filter-incomparable @[m1] m2)]
+    (= 2 (length filtered)))
+  "Antichain filtering keeps incomparable matrices")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:lam (fn [y] [:app [:var "loop"] [:var "x"]])])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls under lambdas")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-pi [:var "Nat"] (fn [y] [:app [:var "loop"] [:var "x"]])])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls under dependent pis")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-sigma [:var "Nat"] (fn [y] [:app [:var "loop"] [:var "x"]])])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls under dependent sigmas")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-id [:var "Nat"] [:var "x"] [:app [:var "loop"] [:var "x"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls inside identity types")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-J [:var "Nat"]
+                                        [:var "x"]
+                                        [:lam (fn [y] [:app [:var "loop"] [:var "x"]])]
+                                        [:var "zero"]
+                                        [:var "x"]
+                                        [:t-refl [:var "x"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls inside J motives")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "p"]]
+                                  [:fst [:app [:var "loop"] [:fst [:var "p"]]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :lt (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery preserves projection-based descent in discovered calls")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "f"]]
+                                  [:app [:var "f"] [:app [:var "loop"] [:var "f"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery records recursive calls inside non-recursive applications only once")
+
+(test/end-suite suite)

--- a/test/Termination/SizeChangeCompare.janet
+++ b/test/Termination/SizeChangeCompare.janet
@@ -31,8 +31,12 @@
   "Second projections count as structural descent")
 
 (test/assert suite
-  (= :lt (term/sc/compare [:pair [:var "x"] [:var "y"]] [:pat/var "x"]))
-  "Pair components count as subterms of the whole pair")
+  (= :unknown (term/sc/compare [:pair [:var "x"] [:var "y"]] [:pat/var "x"]))
+  "Pair construction alone does not count as structural descent")
+
+(test/assert suite
+  (= :eq (term/sc/compare [:fst [:pair [:var "x"] [:var "y"]]] [:pat/var "x"]))
+  "Projecting a concrete pair preserves the exact component comparison")
 
 (test/assert suite
   (= :unknown (term/sc/compare [:app [:var "f"] [:var "x"]] [:pat/var "f"]))
@@ -143,5 +147,11 @@
          (= "loop" ((calls 0) 0))
          (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
   "Call discovery records recursive calls inside non-recursive applications only once")
+
+(test/assert suite
+  (zero? (length (term/sc/find-calls @{"f" 1}
+                                     @[[:pat/var "f"]]
+                                     [:app [:var "f"] [:var "zero"]])))
+  "Call discovery ignores locally bound variables that shadow function names")
 
 (test/end-suite suite)

--- a/test/Termination/SizeChangeCompare.janet
+++ b/test/Termination/SizeChangeCompare.janet
@@ -43,6 +43,12 @@
   "Beta-redexes are reduced before recursive-argument comparison")
 
 (test/assert suite
+  (= :eq (term/sc/compare [:fst [:app [:lam (fn [u] [:pair [:var "x"] [:var "y"]])]
+                                       [:var "unit"]]]
+                          [:pat/var "x"]))
+  "Projection redexes are reduced before recursive-argument comparison")
+
+(test/assert suite
   (= :unknown (term/sc/compare [:app [:var "f"] [:var "x"]] [:pat/var "f"]))
   "Higher-order applications are not mistaken for descent on the head")
 
@@ -60,6 +66,12 @@
   (= :unknown (term/sc/compare [:app [:var "zero"] [:var "n"]]
                                [:pat/con "succ" @[[:pat/var "n"]]]))
   "Different constructor heads do not compare spuriously")
+
+(test/assert suite
+  (= :unknown (term/sc/compare [:app [:var "succ"] [:var "n"]]
+                               [:pat/con "succ" @[[:pat/var "n"]]]
+                               @{"succ" true}))
+  "Bound variables that shadow constructors are not treated as constructor heads")
 
 (test/assert suite
   (= :unknown (term/sc/compare [:var "x"] [:pat/var "_"]))
@@ -136,6 +148,20 @@
 
 (test/assert suite
   (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "x"]]
+                                  [:t-J [:var "Nat"]
+                                        [:var "x"]
+                                        (fn [y p] [:app [:var "loop"] [:var "x"]])
+                                        [:var "zero"]
+                                        [:var "x"]
+                                        [:t-refl [:var "x"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees recursive calls inside HOAS J motives")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
                                   @[[:pat/var "p"]]
                                   [:fst [:app [:var "loop"] [:fst [:var "p"]]]])]
     (and (= 1 (length calls))
@@ -166,5 +192,16 @@
     (and (= 1 (length calls))
          (= "loop" ((calls 0) 0))))
   "Call discovery sees reducible callee heads after local reduction")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "n"]]
+                                  [:app [:fst [:app [:lam (fn [u] [:pair [:var "loop"] [:var "zero"]])]
+                                                   [:var "unit"]]]
+                                        [:var "n"]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))
+         (= :eq (term/sc/matrix-get ((calls 0) 1) 0 0))))
+  "Call discovery sees reducible callee heads hidden behind projection redexes")
 
 (test/end-suite suite)

--- a/test/Termination/SizeChangeCompare.janet
+++ b/test/Termination/SizeChangeCompare.janet
@@ -39,6 +39,10 @@
   "Projecting a concrete pair preserves the exact component comparison")
 
 (test/assert suite
+  (= :eq (term/sc/compare [:app [:lam (fn [x] x)] [:var "n"]] [:pat/var "n"]))
+  "Beta-redexes are reduced before recursive-argument comparison")
+
+(test/assert suite
   (= :unknown (term/sc/compare [:app [:var "f"] [:var "x"]] [:pat/var "f"]))
   "Higher-order applications are not mistaken for descent on the head")
 
@@ -153,5 +157,14 @@
                                      @[[:pat/var "f"]]
                                      [:app [:var "f"] [:var "zero"]])))
   "Call discovery ignores locally bound variables that shadow function names")
+
+(test/assert suite
+  (let [calls (term/sc/find-calls @{"loop" 1}
+                                  @[[:pat/var "n"]]
+                                  [:app [:fst [:pair [:var "loop"] [:var "zero"]]]
+                                        [:app [:var "succ"] [:var "n"]]])]
+    (and (= 1 (length calls))
+         (= "loop" ((calls 0) 0))))
+  "Call discovery sees reducible callee heads after local reduction")
 
 (test/end-suite suite)

--- a/test/Termination/SizeChangeGraph.janet
+++ b/test/Termination/SizeChangeGraph.janet
@@ -286,6 +286,14 @@
                 "2x2 composition preserves decreases on distinct coordinates"
                 (term/sc/matrix->string composed)))
 
+(test/assert suite
+  (let [swap (term/sc/call "swap" "swap"
+                           (mk-matrix 2 2 @[[0 1 :lt] [1 0 :lt]])
+                           [:sc/base-proof "swap" "swap"])
+        result (term/sc/check-graph* @{"swap" 2} @[swap])]
+    (result :ok))
+  "Non-idempotent self-call matrices are not reported as SCT failures")
+
 (let [cases @[
         {:label "self-unknown"
          :nodes @["f"]

--- a/test/Termination/SizeChangeGraph.janet
+++ b/test/Termination/SizeChangeGraph.janet
@@ -294,6 +294,17 @@
     (result :ok))
   "Non-idempotent self-call matrices are not reported as SCT failures")
 
+(test/assert suite
+  (let [m1 (term/sc/call "f" "f"
+                         (mk-matrix 2 2 @[[1 1 :lt]])
+                         [:sc/base-proof "f-1" "f"])
+        m2 (term/sc/call "f" "f"
+                         (mk-matrix 2 2 @[[0 1 :lt] [1 0 :eq]])
+                         [:sc/base-proof "f-2" "f"])
+        result (term/sc/check-graph* @{"f" 2} @[m1 m2])]
+    (result :ok))
+  "SCT repeats closure rounds until stronger summaries dominate bad self matrices")
+
 (let [cases @[
         {:label "self-unknown"
          :nodes @["f"]

--- a/test/Termination/SizeChangeGraph.janet
+++ b/test/Termination/SizeChangeGraph.janet
@@ -1,0 +1,333 @@
+#!/usr/bin/env janet
+
+(import ../Utils/TestRunner :as test)
+(import ../../src/termination :as term)
+
+(def suite (test/start-suite "Termination Size Change Graph"))
+
+(defn mk-matrix [rows cols entries]
+  (let [m (term/sc/matrix rows cols)]
+    (each [row col rel] entries
+      (term/sc/matrix-set m row col rel))
+    m))
+
+(defn rel->string [rel]
+  (case rel
+    :lt "<"
+    :eq "="
+    "?"))
+
+(defn mk-self-call [name rel label]
+  (term/sc/call name name
+                (if (= rel :unknown)
+                  (mk-matrix 1 1 @[])
+                  (mk-matrix 1 1 @[[0 0 rel]]))
+                [:sc/base-proof label name]))
+
+(defn mk-edge [from to rel label]
+  (term/sc/call from to
+                (if (= rel :unknown)
+                  (mk-matrix 1 1 @[])
+                  (mk-matrix 1 1 @[[0 0 rel]]))
+                [:sc/base-proof label to]))
+
+(defn wrap [matrix]
+  {:from "f" :to "f" :matrix matrix :proof [:sc/base-proof "p" "f"]})
+
+(defn ref-rel-mul [r1 r2]
+  (match [r1 r2]
+    [:lt :lt] :lt
+    [:lt :eq] :lt
+    [:eq :lt] :lt
+    [:eq :eq] :eq
+    _ :unknown))
+
+(defn ref-rel-rank [rel]
+  (case rel
+    :lt 2
+    :eq 1
+    0))
+
+(defn ref-rel-max [r1 r2]
+  (if (> (ref-rel-rank r1) (ref-rel-rank r2)) r1 r2))
+
+(defn ref-check-1x1 [nodes edges]
+  (let [best @{}]
+    (each from nodes
+      (let [row @{}]
+        (each to nodes
+          (put row to :unknown))
+        (put best from row)))
+    (each [from to rel] edges
+      (put (best from) to (ref-rel-max ((best from) to) rel)))
+    (var changed true)
+    (while changed
+      (set changed false)
+      (each mid nodes
+        (each from nodes
+          (each to nodes
+            (let [candidate (ref-rel-mul ((best from) mid) ((best mid) to))
+                  current ((best from) to)]
+              (when (> (ref-rel-rank candidate) (ref-rel-rank current))
+                (put (best from) to candidate)
+                (set changed true)))))))
+    (all (fn [node]
+           (= ((best node) node) :lt))
+         nodes)))
+
+(test/assert suite
+  (let [left (mk-matrix 1 2 @[[0 0 :eq] [0 1 :lt]])
+        right (mk-matrix 2 1 @[[0 0 :lt] [1 0 :eq]])
+        composed (term/sc/compose left right)]
+    (and (= "< < | = <" (term/sc/matrix->string composed))
+         (term/sc/matrix-diagonal-has-lt? composed)))
+  "Matrix composition keeps strongest relation across paths")
+
+(test/assert suite
+  (let [strong (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+        weak (mk-matrix 2 2 @[[1 1 :eq]])]
+    (and (term/sc/matrix-dominates? strong weak)
+         (not (term/sc/matrix-dominates? weak strong))))
+  "Matrix dominance orders precise matrices above weaker ones")
+
+(test/assert suite
+  (= "[< ? =]" (term/sc/diagonal->string (mk-matrix 3 3 @[[0 0 :lt] [2 2 :eq]])))
+  "Diagonal rendering exposes decreasing evidence")
+
+(test/assert suite
+  (let [ack-calls @[
+          (term/sc/call "ack" "ack"
+                        (mk-matrix 2 2 @[[0 0 :lt]])
+                        [:sc/base-proof "ack-1" "ack"])
+          (term/sc/call "ack" "ack"
+                        (mk-matrix 2 2 @[[0 0 :eq] [1 1 :lt]])
+                        [:sc/base-proof "ack-2" "ack"])]
+        result (term/sc/check-graph* @{"ack" 2} ack-calls)]
+    (result :ok))
+  "Arend-style mixed decreasing self-call matrices pass SCT closure")
+
+(let [result (term/sc/check-graph*
+               @{"f" 4}
+               @[
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :lt]])
+                               [:sc/base-proof "f-1" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :lt]])
+                               [:sc/base-proof "f-2" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :lt]])
+                               [:sc/base-proof "f-3" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :eq] [3 3 :lt]])
+                               [:sc/base-proof "f-4" "f"])])]
+  (test/assert suite
+    (result :ok)
+    "Arend artificial decreasing chain closes successfully"))
+
+(let [result (term/sc/check-graph*
+               @{"f" 4}
+               @[
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :lt]])
+                               [:sc/base-proof "f-1" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :lt]])
+                               [:sc/base-proof "f-2" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :lt]])
+                               [:sc/base-proof "f-3" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :eq] [1 1 :eq] [2 2 :eq] [3 3 :eq]])
+                               [:sc/base-proof "f-4" "f"])])]
+  (test/assert suite
+    (not (result :ok))
+    "Arend artificial non-decreasing chain is rejected"))
+
+(let [result (term/sc/check-graph*
+               @{"f" 4}
+               @[
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[1 1 :lt] [3 3 :eq]])
+                               [:sc/base-proof "f-2" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[1 1 :eq] [2 2 :lt] [3 3 :eq]])
+                               [:sc/base-proof "f-3" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[3 3 :lt]])
+                               [:sc/base-proof "f-1" "f"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 4 4 @[[0 0 :lt] [1 1 :eq] [2 2 :eq] [3 3 :eq]])
+                               [:sc/base-proof "f-4" "f"])])]
+  (test/assert suite
+    (result :ok)
+    "Arend artificial incomparable matrices still yield a decreasing cycle"))
+
+(let [result (term/sc/check-graph*
+               @{"h" 2 "f" 2 "g" 2}
+               @[
+                 (term/sc/call "h" "h"
+                               (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+                               [:sc/base-proof "h-h-1" "h"])
+                 (term/sc/call "h" "h"
+                               (mk-matrix 2 2 @[[0 0 :eq] [1 1 :lt]])
+                               [:sc/base-proof "h-h-2" "h"])
+                 (term/sc/call "f" "f"
+                               (mk-matrix 2 2 @[[0 1 :lt]])
+                               [:sc/base-proof "f-f" "f"])
+                 (term/sc/call "f" "h"
+                               (mk-matrix 2 2 @[])
+                               [:sc/base-proof "f-h" "h"])
+                 (term/sc/call "f" "g"
+                               (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+                               [:sc/base-proof "f-g" "g"])
+                 (term/sc/call "g" "f"
+                               (mk-matrix 2 2 @[[0 0 :eq] [1 1 :eq]])
+                               [:sc/base-proof "g-f" "f"])
+                 (term/sc/call "g" "g"
+                               (mk-matrix 2 2 @[[0 0 :lt]])
+                               [:sc/base-proof "g-g" "g"])
+                 (term/sc/call "g" "h"
+                               (mk-matrix 2 2 @[])
+                               [:sc/base-proof "g-h" "h"])])]
+  (test/assert suite
+    (not (result :ok))
+    "Arend mixed graph counterexample is rejected"))
+
+(let [result (term/sc/check-graph*
+               @{"v" 1}
+               @[
+                 (term/sc/call "v" "v"
+                               (mk-matrix 1 1 @[])
+                               [:sc/base-proof "unknown" "v"])
+                 (term/sc/call "v" "v"
+                               (mk-matrix 1 1 @[[0 0 :eq]])
+                               [:sc/base-proof "equal" "v"])
+                 (term/sc/call "v" "v"
+                               (mk-matrix 1 1 @[[0 0 :lt]])
+                               [:sc/base-proof "lt" "v"])])]
+  (test/assert suite
+    (and (result :ok)
+         (zero? (length (result :problems))))
+    "Dominating matrices do not interfere with a decreasing witness"))
+
+(let [triples @[
+        @[:unknown :unknown :unknown]
+        @[:unknown :unknown :eq]
+        @[:unknown :eq :eq]
+        @[:eq :eq :eq]
+        @[:lt :unknown :unknown]
+        @[:unknown :lt :eq]
+        @[:eq :eq :lt]
+        @[:lt :lt :lt]]]
+  (each triple triples
+    (let [r1 (triple 0)
+          r2 (triple 1)
+          r3 (triple 2)
+          result (term/sc/check-graph*
+                   @{"f" 1}
+                   @[(mk-self-call "f" r1 "r1")
+                     (mk-self-call "f" r2 "r2")
+                     (mk-self-call "f" r3 "r3")])
+          expect (or (= r1 :lt) (= r2 :lt) (= r3 :lt))]
+      (test/assertf suite
+                    (= expect (result :ok))
+                    "Generated single-node 1x1 SCT cases match diagonal intuition"
+                    (string "rels=" (rel->string r1) "," (rel->string r2) "," (rel->string r3)
+                            " got=" (if (result :ok) "ok" "fail"))))))
+
+(let [pairs @[
+        @[:unknown :unknown]
+        @[:unknown :eq]
+        @[:eq :eq]
+        @[:lt :unknown]
+        @[:unknown :lt]
+        @[:eq :lt]
+        @[:lt :eq]
+        @[:lt :lt]]]
+  (each pair pairs
+    (let [r1 (pair 0)
+          r2 (pair 1)
+          result (term/sc/check-graph*
+                   @{"f" 1 "g" 1}
+                   @[(mk-edge "f" "g" r1 "f-g")
+                     (mk-edge "g" "f" r2 "g-f")])
+          expect (and (not= r1 :unknown)
+                      (not= r2 :unknown)
+                      (or (= r1 :lt) (= r2 :lt)))]
+      (test/assertf suite
+                    (= expect (result :ok))
+                    "Generated two-node 1x1 cycles match composed diagonal intuition"
+                    (string "cycle=" (rel->string r1) "," (rel->string r2)
+                            " got=" (if (result :ok) "ok" "fail"))))))
+
+(let [m00 (wrap (mk-matrix 2 2 @[[0 0 :lt]]))
+      m11 (wrap (mk-matrix 2 2 @[[1 1 :lt]]))
+      meq (wrap (mk-matrix 2 2 @[[0 0 :eq] [1 1 :eq]]))
+      mboth (wrap (mk-matrix 2 2 @[[0 0 :lt] [1 1 :lt]]))
+      kept1 (term/sc/filter-incomparable @[m00] m11)
+      kept2 (term/sc/filter-incomparable kept1 meq)
+      kept3 (term/sc/filter-incomparable kept2 mboth)]
+  (test/assertf suite
+                (and (= 2 (length kept1))
+                     (= 3 (length kept2))
+                     (= 1 (length kept3))
+                     (= "< ? | ? <" (term/sc/matrix->string ((kept3 0) :matrix))))
+                "2x2 antichain filtering keeps incomparable matrices then collapses to stronger witness"
+                (string "after1=" (length kept1) " after2=" (length kept2) " after3=" (length kept3)
+                        " final=" (term/sc/matrix->string ((kept3 0) :matrix)))) )
+
+(let [left (mk-matrix 2 2 @[[0 0 :eq] [1 1 :lt]])
+      right (mk-matrix 2 2 @[[0 0 :lt] [1 1 :eq]])
+      composed (term/sc/compose left right)]
+  (test/assertf suite
+                (and (= "< ? | ? <" (term/sc/matrix->string composed))
+                     (term/sc/matrix-diagonal-has-lt? composed))
+                "2x2 composition preserves decreases on distinct coordinates"
+                (term/sc/matrix->string composed)))
+
+(let [cases @[
+        {:label "self-unknown"
+         :nodes @["f"]
+         :edges @[["f" "f" :unknown]]
+         :calls @[(mk-self-call "f" :unknown "u")]}
+        {:label "self-eq"
+         :nodes @["f"]
+         :edges @[["f" "f" :eq]]
+         :calls @[(mk-self-call "f" :eq "e")]}
+        {:label "self-lt"
+         :nodes @["f"]
+         :edges @[["f" "f" :lt]]
+         :calls @[(mk-self-call "f" :lt "l")]}
+        {:label "mutual-eq-eq"
+         :nodes @["f" "g"]
+         :edges @[["f" "g" :eq] ["g" "f" :eq]]
+         :calls @[(mk-edge "f" "g" :eq "fg") (mk-edge "g" "f" :eq "gf")]}
+        {:label "mutual-lt-eq"
+         :nodes @["f" "g"]
+         :edges @[["f" "g" :lt] ["g" "f" :eq]]
+         :calls @[(mk-edge "f" "g" :lt "fg") (mk-edge "g" "f" :eq "gf")]}
+        {:label "mutual-lt-unknown"
+         :nodes @["f" "g"]
+         :edges @[["f" "g" :lt] ["g" "f" :unknown]]
+         :calls @[(mk-edge "f" "g" :lt "fg") (mk-edge "g" "f" :unknown "gf")]}
+        {:label "mixed-self-and-mutual"
+         :nodes @["f" "g"]
+         :edges @[["f" "f" :eq] ["f" "g" :lt] ["g" "f" :eq]]
+         :calls @[(mk-self-call "f" :eq "ff") (mk-edge "f" "g" :lt "fg") (mk-edge "g" "f" :eq "gf")]}
+        {:label "both-self-lt"
+         :nodes @["f" "g"]
+         :edges @[["f" "f" :lt] ["g" "g" :lt]]
+         :calls @[(mk-self-call "f" :lt "ff") (mk-self-call "g" :lt "gg")]}]]
+  (each specimen cases
+    (let [arities @{}
+          _ (each node (specimen :nodes)
+              (put arities node 1))
+          reference (ref-check-1x1 (specimen :nodes) (specimen :edges))
+          actual ((term/sc/check-graph* arities (specimen :calls)) :ok)]
+      (test/assertf suite
+                    (= reference actual)
+                    "Reference 1x1 closure agrees with SCT on fixed small graphs"
+                    (string (specimen :label) " ref=" reference " actual=" actual)))))
+
+(test/end-suite suite)


### PR DESCRIPTION
## Summary
- implement and tighten size-change termination checking, including recursive-header detection, stronger recursive-argument comparison, and SCC-local closure over call matrices
- run SCT during elaboration so non-terminating definitions are rejected with explicit termination diagnostics while keeping the current `cpo` entrypoints as stubs
- add focused regression coverage for end-to-end termination behavior, compare/call-discovery internals, graph and antichain behavior, and agreement with a tiny reference checker on small 1x1 cases

## Testing
- janet test/Termination/SizeChange.janet
- janet test/Termination/SizeChangeCompare.janet
- janet test/Termination/SizeChangeGraph.janet
- janet test/Elab/Elab.janet
- jpm test