### PR TITLE
fix: make constraint solving and hole filling live

### DIFF
--- a/examples/clause-hole-fill.requiem
+++ b/examples/clause-hole-fill.requiem
@@ -1,0 +1,7 @@
+Nat:
+  zero
+  succ Nat
+
+id(n: Nat): Nat
+  zero = ?goal
+  succ k = succ k

--- a/examples/hole-fill.requiem
+++ b/examples/hole-fill.requiem
@@ -1,0 +1,5 @@
+Nat:
+  zero
+  succ Nat
+
+check ?goal : Nat

--- a/examples/holes.requiem
+++ b/examples/holes.requiem
@@ -1,0 +1,1 @@
+check ?goal : Type1

--- a/requiem.janet
+++ b/requiem.janet
@@ -715,6 +715,12 @@
 
     _ Γ))
 
+(defn- clause/body [clause]
+  (match clause
+    [:core/clause _ body] body
+    _ (or (clause :body)
+          (errorf "unknown clause representation: %v" clause))))
+
 (defn- build-ctor-env [core-decls]
   (let [ctors @{}
         ctor-name-set @{}]
@@ -806,20 +812,19 @@
         (when (check :error)
           (error (check :error)))
         (let [filled-report ((reports/exports :report/from-state) (check :constraints) (check :goals) @{})]
-        (printf "\nFilled ?%s with %s" hole-name (pp/print/tm replacement-core))
-        (printf "  In: %s : %s" (pp/print/tm tm) (pp/print/tm ty))
-        (printf "  => %s" (pp/print/tm (filled :term)))
-        (print "  => OK")
-        (let [entries (report/entries filled-report)]
-          (when (> (length entries) 0)
-            (print "  Remaining goals:")
-            (print/goals entries global-name-set @[preferred-names] nil "    ")))
-        true))
+          (printf "\nFilled ?%s with %s" hole-name (pp/print/tm replacement-core))
+          (printf "  In: %s : %s" (pp/print/tm tm) (pp/print/tm ty))
+          (printf "  => %s" (pp/print/tm (filled :term)))
+          (print "  => OK")
+          (let [entries (report/entries filled-report)]
+            (when (> (length entries) 0)
+              (print "  Remaining goals:")
+              (print/goals entries global-name-set @[preferred-names] nil "    ")))
+          true))
       false)))
 
 (defn- fill/candidates [core global-ctx ctor-env lowered-check-names]
-  (let [out @[]
-        ]
+  (let [out @[]]
     (var check-goal-index 0)
     (each decl core
       (match decl
@@ -827,7 +832,7 @@
         (let [Γ (binders->ctx params global-ctx)]
           (eachp [i clause] clauses
             (array/push out {:label (string "function " name " clause " (+ i 1))
-                             :tm (clause 2)
+                             :tm (clause/body clause)
                              :ty result
                              :ctx (clause/extend-ctx Γ params clause ctor-env)
                              :preferred-names @[]})))

--- a/requiem.janet
+++ b/requiem.janet
@@ -3,6 +3,7 @@
 (import ./src/frontend/surface/parser :as sp)
 (import ./src/elab :as e)
 (import ./src/coreTT :as tt)
+(import ./src/reports :as reports)
 (import ./src/sig :as sig)
 (import /build/hamt :as h)
 (import /build/timer :as timer)
@@ -292,12 +293,6 @@
                            start-next
                            (fn [] (print/goal-sem sem)))))
 
-(defn- tt/goals/restore! [saved-goals saved-collect]
-  (array/clear tt/goals)
-  (each g saved-goals
-    (array/push tt/goals g))
-  (tt/goals/set-collect! saved-collect))
-
 (defn- partition/goal-ctx [ctx hidden-names]
   (reduce (fn [[local global] entry]
             (if (get hidden-names (entry 0))
@@ -373,7 +368,7 @@
     (printf "%sAvailable names:" indent)
     (print/bindings global-ctx (string indent "  ") local-names)
     (printf "%s------------------------------" indent)
-    (printf "%s?%s : %s" indent (string (g :name)) (print/goal-type (g :expected) local-names))))
+    (printf "%s?%s : %s" indent (or (g :name) "_") (print/goal-type (g :expected) local-names))))
 
 (defn- print/goals [goals hidden-names preferred-name-groups &opt header indent]
   (let [indent (or indent "  ")]
@@ -389,6 +384,23 @@
                           indent)
         (when (< (+ i 1) (length goals))
           (print ""))))))
+
+(defn- report/entries [report]
+  (array/concat (array/slice (report :pending-goals))
+                (array/slice (report :constraints))))
+
+(defn- report/find-entry [report hole-name]
+  (find |(and ($ :name) (= ($ :name) hole-name))
+        (report/entries report)))
+
+(defn- result/empty []
+  {:constraints @[] :goals @[]})
+
+(defn- result/merge [left right]
+  {:constraints (array/concat (array/slice (left :constraints))
+                              (or (right :constraints) @[]))
+   :goals (array/concat (array/slice (left :goals))
+                        (or (right :goals) @[]))})
 
 (defn- global-names [Γ]
   (reduce (fn [acc k]
@@ -429,15 +441,18 @@
   (print "Modes:")
   (print "  run      parse, elaborate, and execute compute blocks")
   (print "  check    parse and elaborate without running compute blocks")
+  (print "  fill     fill a named hole in check blocks")
   (print "  compile  alias of run")
   (print "  help     show this help")
   (print "")
   (print "Input:")
   (print "  the CLI accepts `.requiem` source files only")
+  (print "  fill syntax: requiem fill <file> <hole-name> <expr>")
   (print "")
   (print "Examples:")
   (print "  requiem examples/test.requiem")
   (print "  requiem check examples/test.requiem")
+  (print "  requiem fill examples/holes.requiem goal \"Type0\"")
   (print "  requiem compile @examples/test.requiem"))
 
 (defn- print/surface-type [ty]
@@ -562,6 +577,22 @@
                   (fn [x]
                     (recur (+ i 1) (tt/ctx/add cur-ctx name x)))))))
   (recur 0 Γ))
+
+(defn- sig-env/from-decls [decls]
+  (reduce (fn [acc decl]
+            (match decl
+              [:decl/func name params _ _]
+              (array/push acc [name params])
+              _ acc))
+          @[]
+          decls))
+
+(defn- env/from-goal-ctx [ctx]
+  (reduce (fn [acc entry]
+            (array/push acc [(entry 0) [:var (entry 0)]])
+            acc)
+          @[]
+          ctx))
 
 (defn- build-global-ctx [core-decls]
   (var Γ (tt/ctx/empty))
@@ -696,19 +727,25 @@
         _ nil))
     {:ctors ctors :ctor-name-set ctor-name-set}))
 
+(defn- check/live [Γ tm expected-sem]
+  (let [result (tt/check/c Γ tm expected-sem)]
+    (when (result :error)
+      (error (result :error)))
+    result))
+
 (defn- check/with-ctors [Γ tm expected-core ctor-env]
   (let [expected-sem (tt/eval Γ expected-core)
         [head args] (term/spine tm)
         info (and head (get (ctor-env :ctors) head))]
     (cond
       (nil? info)
-      (tt/check Γ tm expected-sem)
+      (check/live Γ tm expected-sem)
 
       true
       (let [[exp-head exp-args] (term/spine expected-core)]
         (cond
           (or (nil? exp-head) (not= exp-head (info :data)))
-          (tt/check Γ tm expected-sem)
+          (check/live Γ tm expected-sem)
 
           true
           (let [ctor (info :ctor)
@@ -724,96 +761,204 @@
                           head
                           (length params)
                           (length args)))
-                (for i 0 (length params)
-                  (let [arg (args i)
-                        param-ty (term/subst ((params i) 2) sigma)]
-                    (check/with-ctors Γ arg param-ty ctor-env)))
-                true)
-              (tt/check Γ tm expected-sem))))))))
+                (reduce (fn [acc i]
+                          (let [arg (args i)
+                                param-ty (term/subst ((params i) 2) sigma)]
+                            (result/merge acc (check/with-ctors Γ arg param-ty ctor-env))))
+                        (result/empty)
+                        (range (length params))))
+              (check/live Γ tm expected-sem))))))))
 
-(defn run/file-surface [path mode]
-  (def start-ms (timer/ms))
+(defn- program/load [path]
   (def src (with-default-prelude (string (slurp path))))
   (print "Parsing " path "...")
   (def prog (sp/parse/program src))
-  (def surface-type-holes @[])
-  (each decl (prog 1)
-    (collect/decl-type-holes decl surface-type-holes))
+  (def surface-type-holes ((reports/exports :report/type-holes) prog collect/decl-type-holes))
   (def lowered (sp/lower/program prog))
-  (def lowered-check-names
-    (reduce (fn [acc decl]
-              (match decl
-                [:decl/check tm _]
-                [;acc (term/lambda-names tm)]
-                _ acc))
-            @[]
-            lowered))
+  (def resolved ((e/exports :resolve-decls) lowered))
+  (def lowered-check-names ((reports/exports :report/check-name-hints) lowered term/lambda-names))
+  (def sig-env (sig-env/from-decls resolved))
   (print/decls lowered)
   (def core (e/elab/program lowered))
   (def runtime-sig (sig/sig/build core))
   (def global-ctx (build-global-ctx core))
   (def global-name-set (global-names global-ctx))
-  (print/type-hole-goals surface-type-holes global-name-set)
   (def ctor-env (build-ctor-env core))
+  {:prog prog
+   :surface-type-holes surface-type-holes
+   :lowered lowered
+   :resolved resolved
+   :lowered-check-names lowered-check-names
+   :sig-env sig-env
+   :core core
+   :runtime-sig runtime-sig
+   :global-ctx global-ctx
+   :global-name-set global-name-set
+   :ctor-env ctor-env})
+
+(defn- fill/check-report! [tm ty Γ hole-name replacement-node sig-env ctor-env global-name-set preferred-names]
+  (let [initial (check/with-ctors Γ tm ty ctor-env)
+        report ((reports/exports :report/from-state) (initial :constraints) (initial :goals) @{})]
+    (if-let [entry (report/find-entry report hole-name)]
+      (let [replacement-core ((e/exports :term/elab-in-sig) (env/from-goal-ctx (entry :ctx)) sig-env replacement-node)
+            filled (tt/fill-hole Γ tm (tt/eval Γ ty) hole-name replacement-core)
+            check (filled :check)]
+        (when (check :error)
+          (error (check :error)))
+        (let [filled-report ((reports/exports :report/from-state) (check :constraints) (check :goals) @{})]
+        (printf "\nFilled ?%s with %s" hole-name (pp/print/tm replacement-core))
+        (printf "  In: %s : %s" (pp/print/tm tm) (pp/print/tm ty))
+        (printf "  => %s" (pp/print/tm (filled :term)))
+        (print "  => OK")
+        (let [entries (report/entries filled-report)]
+          (when (> (length entries) 0)
+            (print "  Remaining goals:")
+            (print/goals entries global-name-set @[preferred-names] nil "    ")))
+        true))
+      false)))
+
+(defn- fill/candidates [core global-ctx ctor-env lowered-check-names]
+  (let [out @[]
+        ]
+    (var check-goal-index 0)
+    (each decl core
+      (match decl
+        [:core/func name params result _ty clauses]
+        (let [Γ (binders->ctx params global-ctx)]
+          (eachp [i clause] clauses
+            (array/push out {:label (string "function " name " clause " (+ i 1))
+                             :tm (clause 2)
+                             :ty result
+                             :ctx (clause/extend-ctx Γ params clause ctor-env)
+                             :preferred-names @[]})))
+
+        [:core/check tm ty]
+        (do
+          (array/push out {:label (string "check block " (+ check-goal-index 1))
+                           :tm tm
+                           :ty ty
+                           :ctx global-ctx
+                           :preferred-names (if (< check-goal-index (length lowered-check-names))
+                                              (lowered-check-names check-goal-index)
+                                              @[])})
+          (++ check-goal-index))
+        _ nil))
+    out))
+
+(defn- fill/find-targets [candidates hole-name ctor-env]
+  (reduce (fn [acc candidate]
+            (let [result (check/with-ctors (candidate :ctx) (candidate :tm) (candidate :ty) ctor-env)
+                  report ((reports/exports :report/from-state) (result :constraints) (result :goals) @{})]
+              (if (report/find-entry report hole-name)
+                [;acc {:candidate candidate :result result}]
+                acc)))
+          @[]
+          candidates))
+
+(defn run/file-surface [path mode]
+  (def start-ms (timer/ms))
+  (def state (program/load path))
+  (def lowered (state :lowered))
+  (def lowered-check-names (state :lowered-check-names))
+  (def core (state :core))
+  (def runtime-sig (state :runtime-sig))
+  (def global-ctx (state :global-ctx))
+  (def global-name-set (state :global-name-set))
+  (def ctor-env (state :ctor-env))
+  (print/type-hole-goals (state :surface-type-holes) global-name-set)
   (var check-goal-index 0)
-  (def goal-name-hints @[])
-  (let [saved-goals (slice tt/goals 0)
-        saved-collect (tt/goals/collect?)]
-    (tt/goals/set-collect! true)
-    (array/clear tt/goals)
-    (try
-      (do
-        (each decl core
-          (match decl
-            [:core/func name params result ty clauses]
-            (do
-              (let [Γ (binders->ctx params global-ctx)
-                    expected result]
-                (each c clauses
-                  (check/with-ctors Γ (c 2) expected ctor-env))))
+  (var all-results (result/empty))
+  (each decl core
+    (match decl
+      [:core/func _name params result _ty clauses]
+      (let [Γ (binders->ctx params global-ctx)
+            expected result]
+        (each c clauses
+          (set all-results
+               (result/merge all-results
+                             (check/with-ctors (clause/extend-ctx Γ params c ctor-env)
+                                               (c 2)
+                                               expected
+                                               ctor-env)))))
 
-            [:core/compute tm]
-            (when (mode/runs-computes? mode)
-              (printf "\nCompute: %s" (pp/print/tm tm))
-              (let [ty (tt/infer global-ctx tm)
-                    res (tt/nf/in-sig global-ctx runtime-sig ty tm)]
-                 (printf "  => %s" (pp/print/nf res))))
+      [:core/compute tm]
+      (when (mode/runs-computes? mode)
+        (printf "\nCompute: %s" (pp/print/tm tm))
+        (let [ty (tt/infer global-ctx tm)
+              res (tt/nf/in-sig global-ctx runtime-sig ty tm)]
+          (printf "  => %s" (pp/print/nf res))))
 
-            [:core/check tm ty]
-            (do
-              (def preferred-names (if (< check-goal-index (length lowered-check-names))
-                                     (lowered-check-names check-goal-index)
-                                     @[]))
-              (++ check-goal-index)
-              (def goal-count-before (length tt/goals))
-              (printf "\nCheck: %s : %s" (pp/print/tm tm) (pp/print/tm ty))
-              (check/with-ctors global-ctx tm ty ctor-env)
-              (print "  => OK")
-              (let [goal-count-after (length tt/goals)]
-                (when (> goal-count-after goal-count-before)
-                  (for _ goal-count-before goal-count-after
-                    (array/push goal-name-hints preferred-names))
-                  (print "  Current goal:")
-                  (print/goals (slice tt/goals goal-count-before goal-count-after)
-                               global-name-set
-                               (slice goal-name-hints goal-count-before goal-count-after)
-                               nil
-                               "    "))))
-             _ nil))
+      [:core/check tm ty]
+      (let [preferred-names (if (< check-goal-index (length lowered-check-names))
+                              (lowered-check-names check-goal-index)
+                              @[])
+            result (check/with-ctors global-ctx tm ty ctor-env)
+            report ((reports/exports :report/from-state) (result :constraints) (result :goals) @{})
+            entries (report/entries report)]
+        (++ check-goal-index)
+        (set all-results (result/merge all-results result))
+        (printf "\nCheck: %s : %s" (pp/print/tm tm) (pp/print/tm ty))
+        (print "  => OK")
+        (when (> (length entries) 0)
+          (print "  Current goal:")
+          (print/goals entries
+                       global-name-set
+                       @[preferred-names]
+                       nil
+                       "    ")))
+      _ nil))
 
-        (let [pending tt/goals]
-          (print/goals pending global-name-set goal-name-hints "\nUnsolved goals:" "  "))
+  (let [pending-report ((reports/exports :report/from-state)
+                        (all-results :constraints)
+                        (all-results :goals)
+                        @{})]
+    (print/goals (report/entries pending-report) global-name-set @[] "\nUnsolved goals:" "  "))
 
-        (print "")
-        (def elapsed-ms (- (timer/ms) start-ms))
-        (printf "Done. %d declaration(s) in %.3fs" (length lowered) (/ elapsed-ms 1000.0))
-        (tt/goals/restore! saved-goals saved-collect))
-      ([err]
-       (tt/goals/restore! saved-goals saved-collect)
-       (error err)))))
+  (print "")
+  (def elapsed-ms (- (timer/ms) start-ms))
+  (printf "Done. %d declaration(s) in %.3fs" (length lowered) (/ elapsed-ms 1000.0)))
+
+(defn run/fill-file-surface [path hole-name replacement-text]
+  (def start-ms (timer/ms))
+  (def state (program/load path))
+  (def replacement-node (sp/parse/expr-text replacement-text))
+  (def core (state :core))
+  (def global-name-set (state :global-name-set))
+  (def ctor-env (state :ctor-env))
+  (def sig-env (state :sig-env))
+  (def global-ctx (state :global-ctx))
+  (def lowered-check-names (state :lowered-check-names))
+  (print/type-hole-goals (state :surface-type-holes) global-name-set)
+  (let [candidates (fill/candidates core global-ctx ctor-env lowered-check-names)
+        matches (fill/find-targets candidates hole-name ctor-env)]
+    (when (= (length matches) 0)
+      (errorf "no fillable goal named ?%s was found" hole-name))
+    (when (> (length matches) 1)
+      (errorf "goal ?%s is ambiguous; found %d matches: %v"
+              hole-name
+              (length matches)
+              (map |(($ :candidate) :label) matches)))
+    (let [target ((matches 0) :candidate)]
+      (printf "\nTarget: %s" (target :label))
+      (fill/check-report! (target :tm)
+                          (target :ty)
+                          (target :ctx)
+                          hole-name
+                          replacement-node
+                          sig-env
+                          ctor-env
+                          global-name-set
+                          (target :preferred-names))))
+  (print "")
+  (def elapsed-ms (- (timer/ms) start-ms))
+  (printf "Done. filled ?%s in %.3fs" hole-name (/ elapsed-ms 1000.0)))
 
 (defn run/file [path mode]
-  (run/file-surface (resolve-path path) mode))
+  (match mode
+    [:fill hole-name replacement-text]
+    (run/fill-file-surface (resolve-path path) hole-name replacement-text)
+    _
+    (run/file-surface (resolve-path path) mode)))
 
 (defn- parse/cli [args]
   (let [args (if (and (> (length args) 0)
@@ -836,6 +981,11 @@
         "check" [:check (args 1)]
         "compile" [:compile (args 1)]
         "help" [:help nil]
+        _ nil)
+
+      (= n 4)
+      (match (args 0)
+        "fill" [[:fill (args 2) (args 3)] (args 1)]
         _ nil)
 
       true

--- a/src/checker.janet
+++ b/src/checker.janet
@@ -27,7 +27,11 @@
         print/tm (deps :print/tm)
         meta (deps :meta)
         constraints (deps :constraints)
-        unify (deps :unify)]
+        unify (deps :unify)
+        goals (meta :goals)
+        goals/reset! (meta :reset!)
+        goals/set-collect! (meta :set-collect!)
+        goals/collect? (meta :collect?)]
 
     (var infer nil)
     (var check nil)
@@ -383,34 +387,68 @@
           true
           cs)))
 
-    (defn infer/c [Γ t]
-      "Infer type with constraint generation"
-      (let [result (infer Γ t)
-            constraints (constraints/gen Γ t result)]
-        {:result result :constraints constraints}))
+    (defn collect/goals [thunk]
+      (let [saved-collect (goals/collect?)
+            saved-goals (array/slice goals)]
+        (goals/reset!)
+        (goals/set-collect! true)
+        (try
+          (let [result (thunk)
+                fresh-goals (array/slice goals)]
+            (goals/reset!)
+            (each goal saved-goals
+              (array/push goals goal))
+            (goals/set-collect! saved-collect)
+            {:result result :goals fresh-goals})
+          ([err]
+           (goals/reset!)
+           (each goal saved-goals
+             (array/push goals goal))
+           (goals/set-collect! saved-collect)
+           (error err)))))
 
     (defn solve-constraints [constraints]
       "Solve a list of constraints using unification"
-      (unify :unify/solve constraints))
+      ((unify :unify/solve) constraints))
+
+    (defn solve-goals [goals]
+      ((constraints :constraints/from-goals) goals))
+
+    (defn infer/c [Γ t]
+      "Infer type while collecting live goal constraints"
+      (let [collected (collect/goals (fn [] (infer Γ t)))]
+        {:result (collected :result)
+         :constraints (solve-goals (collected :goals))
+         :goals (collected :goals)}))
 
     (defn infer/constraint [Γ t expected]
       "Constraint-based inference: infer type and solve constraints against expected type"
       (try
-        (let [inferred (infer Γ t)
-              constraints (constraints/gen Γ t expected)
-              solved (solve-constraints constraints)]
-          (if (empty? solved)
-            {:result inferred :solved true}
-            {:result inferred :constraints solved :solved false}))
+        (let [result (collect/goals
+                       (fn []
+                         (let [inferred (infer Γ t)]
+                           (when expected
+                             (when (not (subtype inferred expected))
+                               (errorf "type mismatch between expected type and inferred type\nExpected: %s\nInferred: %s"
+                                       (print/sem expected)
+                                       (print/sem inferred))))
+                           inferred)))
+              solved (solve-goals (result :goals))]
+          {:result (result :result)
+           :constraints solved
+           :goals (result :goals)
+           :solved (all |($ :solution) solved)})
         ([e]
           {:error e :solved false})))
 
     (defn check/c [Γ t A]
-      "Check term against type with constraint generation"
+      "Check term against type while collecting live goal constraints"
       (try
-        (let [result (check Γ t A)
-              constraints (constraints/gen Γ t A)]
-          {:result result :constraints constraints})
+        (let [result (collect/goals (fn [] (check Γ t A)))
+              solved (solve-goals (result :goals))]
+          {:result (result :result)
+           :constraints solved
+           :goals (result :goals)})
         ([e]
           {:error e :constraints @[]})))
 

--- a/src/checker.janet
+++ b/src/checker.janet
@@ -7,6 +7,7 @@
         T/Refl (deps :T/Refl)
         T/Pair (deps :T/Pair)
         T/Neutral (deps :T/Neutral)
+        T/Meta (deps :T/Meta)
         ty/type (deps :ty/type)
         ty/pi (deps :ty/pi)
         eq-type (deps :eq-type)
@@ -21,6 +22,7 @@
         ctx/add (deps :ctx/add)
         ctx/lookup (deps :ctx/lookup)
         ne/app (deps :ne/app)
+        ne/meta (deps :ne/meta)
         ne/var (deps :ne/var)
         ne/fst (deps :ne/fst)
         print/sem (deps :print/sem)
@@ -30,6 +32,8 @@
         unify (deps :unify)
         goals (meta :goals)
         goals/reset! (meta :reset!)
+        meta/snapshot (meta :snapshot)
+        meta/restore! (meta :restore!)
         goals/set-collect! (meta :set-collect!)
         goals/collect? (meta :collect?)]
 
@@ -69,6 +73,7 @@
       (let [tag (tag-of p-sem)]
         (cond
           (= tag T/Pair) (get p-sem 1)
+          (= tag T/Meta) (sem/neutral (ne/fst (ne/meta (get p-sem 1))))
           (= tag T/Neutral) (sem/neutral (ne/fst (get p-sem 1)))
           true (errorf "fst expected pair semantics, got: %s" (print/sem p-sem)))))
 
@@ -81,15 +86,18 @@
       (let [tag (tag-of f-ty)]
         (if (= tag T/Pi)
           (let [[_tag A B] f-ty
-                B-sem (B arg-sem)
-                ftag (tag-of f-sem)]
-            {:ty B-sem
-             :sem (cond
-                    (= ftag T/Neutral)
-                    (raise B-sem (ne/app (get f-sem 1) (lower A arg-sem)))
+                 B-sem (B arg-sem)
+                 ftag (tag-of f-sem)]
+             {:ty B-sem
+              :sem (cond
+                     (or (= ftag T/Neutral) (= ftag T/Meta))
+                     (raise B-sem (ne/app (if (= ftag T/Meta)
+                                           (ne/meta (get f-sem 1))
+                                           (get f-sem 1))
+                                         (lower A arg-sem)))
 
-                    (function? f-sem)
-                    (f-sem arg-sem)
+                     (function? f-sem)
+                     (f-sem arg-sem)
 
                     true
                     (errorf "expected function semantics for application, got: %v" f-sem))})
@@ -388,23 +396,16 @@
           cs)))
 
     (defn collect/goals [thunk]
-      (let [saved-collect (goals/collect?)
-            saved-goals (array/slice goals)]
+      (let [saved-state (meta/snapshot)]
         (goals/reset!)
         (goals/set-collect! true)
         (try
           (let [result (thunk)
                 fresh-goals (array/slice goals)]
-            (goals/reset!)
-            (each goal saved-goals
-              (array/push goals goal))
-            (goals/set-collect! saved-collect)
+            (meta/restore! saved-state)
             {:result result :goals fresh-goals})
           ([err]
-           (goals/reset!)
-           (each goal saved-goals
-             (array/push goals goal))
-           (goals/set-collect! saved-collect)
+           (meta/restore! saved-state)
            (error err)))))
 
     (defn solve-constraints [constraints]

--- a/src/constraints.janet
+++ b/src/constraints.janet
@@ -46,6 +46,21 @@
   "Create an implicit argument constraint"
   (constraint/make mv name expected nil (ctx/from-env env) (or origin :elab/implicit) dependencies))
 
+(defn constraints/from-goals [goals]
+  (reduce (fn [acc i]
+            (let [goal (goals i)
+                  mv (symbol (string "?goal" (+ i 1)))]
+              (array/push acc
+                          (constraint/make mv
+                                           (goal :name)
+                                           (goal :expected)
+                                           nil
+                                           (goal :ctx)
+                                           :meta/goal))
+              acc))
+          @[]
+          (range (length goals))))
+
 (defn- goals/expected-map [goals]
   (reduce (fn [acc goal]
             (if (goal :name)
@@ -140,6 +155,7 @@
    :constraint/dependent constraint/dependent
    :constraint/level constraint/level
    :constraint/implicit constraint/implicit
+   :constraints/from-goals constraints/from-goals
    :constraint/merge-goals constraint/merge-goals
    :constraint/mv-set constraint/mv-set
    :constraint/name-map constraint/name-map

--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -19,6 +19,7 @@
 (def T/Refl 0x10)
 (def T/Neutral 0x20)
 (def T/Pair 0x40)
+(def T/Meta 0x80)
 
 # Normal Form Tags
 (def NF/Neut 0x100)
@@ -64,6 +65,7 @@
 (defn ne/fst [p] [:nfst p])
 (defn ne/snd [p] [:nsnd p])
 (defn ne/J [A x P d y p] [:nJ A x P d y p])
+(defn ne/meta [id] [:nmeta id])
 
 (defn nf/neut [ne] [NF/Neut ne])
 (defn nf/lam [body] [NF/Lam body])
@@ -102,6 +104,7 @@
 (var sem-eq nil)
 (var runtime-sig nil)
 (var delta/whnf nil)
+(var meta/value nil)
 
 (defn- term/spine [tm]
   (var cur tm)
@@ -211,10 +214,21 @@
         (= tag T/Id)
         (= tag T/Refl)
         (= tag T/Neutral)
+        (= tag T/Meta)
         (= tag T/Pair))))
 
 (defn- sem/neutral [ne]
   [T/Neutral ne])
+
+(defn- sem/meta [id]
+  [T/Meta id])
+
+(defn- sem/head-neutral [sem]
+  (let [tag (tag-of sem)]
+    (cond
+      (= tag T/Neutral) (get sem 1)
+      (= tag T/Meta) (ne/meta (get sem 1))
+      true nil)))
 
 (defn- named-neutral [A fresh]
   (raise A (ne/var fresh)))
@@ -229,8 +243,9 @@
     (if (= tag T/Pi)
       (let [[_ A B] f-ty
             stag (tag-of f-sem)]
-        (cond
-          (= stag T/Neutral) (raise (B arg-sem) (ne/app (get f-sem 1) (lower A arg-sem)))
+         (cond
+          (or (= stag T/Neutral) (= stag T/Meta))
+          (raise (B arg-sem) (ne/app (sem/head-neutral f-sem) (lower A arg-sem)))
           (function? f-sem) (f-sem arg-sem)
           true (errorf "expected function semantics, got: %v" f-sem)))
       (errorf "expected Pi type for semantic application, got: %v" f-ty))))
@@ -312,6 +327,7 @@
   (let [tag (tag-of sem)]
     (cond
       (= tag T/Neutral) (nf/neut (get sem 1))
+      (= tag T/Meta) (nf/neut (ne/meta (get sem 1)))
       (= tag T/Type) (nf/type (get sem 1))
       (= tag T/Pi) (let [[_ A B] sem]
                      (nf/pi (lower/type A)
@@ -329,13 +345,24 @@
 
 (defn- lower/pi [A B sem]
   (let [stag (tag-of sem)]
-    (if (= stag T/Neutral)
+    (cond
+      (= stag T/Neutral)
       (let [ne (get sem 1)]
         (nf/lam
           (fn [fresh]
             (let [arg-sem (named-neutral A fresh)]
               (lower (B arg-sem)
                      (raise (B arg-sem) (ne/app ne (lower A arg-sem))))))))
+
+      (= stag T/Meta)
+      (let [ne (ne/meta (get sem 1))]
+        (nf/lam
+          (fn [fresh]
+            (let [arg-sem (named-neutral A fresh)]
+              (lower (B arg-sem)
+                     (raise (B arg-sem) (ne/app ne (lower A arg-sem))))))))
+
+      true
       (nf/lam
         (fn [fresh]
           (let [arg-sem (named-neutral A fresh)]
@@ -343,11 +370,20 @@
 
 (defn- lower/sigma [A B sem]
   (let [stag (tag-of sem)]
-    (if (= stag T/Neutral)
+    (cond
+      (= stag T/Neutral)
       (let [ne (get sem 1)
             v1 (raise A (ne/fst ne))
             v2 (raise (B v1) (ne/snd ne))]
         (nf/pair (lower A v1) (lower (B v1) v2)))
+
+      (= stag T/Meta)
+      (let [ne (ne/meta (get sem 1))
+            v1 (raise A (ne/fst ne))
+            v2 (raise (B v1) (ne/snd ne))]
+        (nf/pair (lower A v1) (lower (B v1) v2)))
+
+      true
       (let [[_ v1 v2] sem]
         (nf/pair (lower A v1) (lower (B v1) v2))))))
 
@@ -355,6 +391,7 @@
   (let [stag (tag-of sem)]
     (cond
       (= stag T/Refl) (nf/refl (lower (get ty 1) (get sem 1)))
+      (= stag T/Meta) (nf/neut (ne/meta (get sem 1)))
       (= stag T/Neutral) (nf/neut (get sem 1))
       true sem)))
 
@@ -362,7 +399,9 @@
   (let [stag (tag-of sem)]
     (if (= stag T/Neutral)
       (nf/neut (get sem 1))
-      sem)))
+      (if (= stag T/Meta)
+        (nf/neut (ne/meta (get sem 1)))
+        sem))))
 
 (set lower
      (fn [ty sem]
@@ -382,6 +421,7 @@
                  :T/Id T/Id
                  :T/Refl T/Refl
                  :T/Neutral T/Neutral
+                 :T/Meta T/Meta
                  :T/Pair T/Pair
                  :NF/Neut NF/Neut
                  :NF/Lam NF/Lam
@@ -451,6 +491,7 @@
          (not (and (tuple? ne1) (tuple? ne2))) (= ne1 ne2)
          (not= (get ne1 0) (get ne2 0)) false
          (= (get ne1 0) :nvar) (= (get ne1 1) (get ne2 1))
+         (= (get ne1 0) :nmeta) (= (get ne1 1) (get ne2 1))
          (= (get ne1 0) :napp)
          (and (ne-eq (get ne1 1) (get ne2 1))
               (nf-eq (get ne1 2) (get ne2 2)))
@@ -571,16 +612,22 @@
 
 (set sem-eq
      (fn [ty v1 v2]
-        "Check if two semantic values are equal at given type (with eta)"
+         "Check if two semantic values are equal at given type (with eta)"
        (if (= v1 v2)
          true
-         (let [tag (tag-of ty)]
-           (cond
-             (= tag T/Type) (sem-eq/type ty v1 v2)
-             (= tag T/Pi) (let [[_ A B] ty] (sem-eq/pi A B v1 v2))
-             (= tag T/Sigma) (let [[_ A B] ty] (sem-eq/sigma A B v1 v2))
-             (= tag T/Id) (let [[_ A _ _] ty] (sem-eq/id A v1 v2))
-             true false)))))
+         (let [tag1 (tag-of v1)
+               tag2 (tag-of v2)]
+           (if (or (= tag1 T/Meta) (= tag2 T/Meta))
+             (and (= tag1 T/Meta)
+                  (= tag2 T/Meta)
+                  (= (get v1 1) (get v2 1)))
+             (let [tag (tag-of ty)]
+               (cond
+                 (= tag T/Type) (sem-eq/type ty v1 v2)
+                 (= tag T/Pi) (let [[_ A B] ty] (sem-eq/pi A B v1 v2))
+                 (= tag T/Sigma) (let [[_ A B] ty] (sem-eq/sigma A B v1 v2))
+                 (= tag T/Id) (let [[_ A _ _] ty] (sem-eq/id A v1 v2))
+                 true false)))))))
 
 (defn- eval/var [Γ x]
   (if (or (string? x) (symbol? x))
@@ -592,17 +639,29 @@
 
 (defn- eval/app [Γ f x]
   (let [fv (eval Γ f)
-         xv (eval Γ x)
-         tag (tag-of fv)]
-      (if (= tag T/Neutral)
-        (let [fA (infer Γ f)
-              ftag (tag-of fA)]
-          (if (= ftag T/Pi)
-            (let [[_ A _] fA]
-              (sem/neutral (ne/app (get fv 1) (lower A xv))))
-            (errorf "cannot apply neutral term with non-function type: %s"
-                    (print/sem fA))))
-        (fv xv))))
+        xv (eval Γ x)
+        tag (tag-of fv)]
+    (cond
+      (= tag T/Neutral)
+      (let [fA (infer Γ f)
+            ftag (tag-of fA)]
+        (if (= ftag T/Pi)
+          (let [[_ A _] fA]
+            (sem/neutral (ne/app (get fv 1) (lower A xv))))
+          (errorf "cannot apply neutral term with non-function type: %s"
+                  (print/sem fA))))
+
+      (= tag T/Meta)
+      (let [fA (infer Γ f)
+            ftag (tag-of fA)]
+        (if (= ftag T/Pi)
+          (let [[_ A _] fA]
+            (sem/neutral (ne/app (ne/meta (get fv 1)) (lower A xv))))
+          (errorf "cannot apply meta term with non-function type: %s"
+                  (print/sem fA))))
+
+      true
+      (fv xv))))
 
 (defn- eval/t-pi [Γ A B]
   (ty/pi (eval Γ A) (fn [x] (eval Γ (B x)))))
@@ -621,6 +680,7 @@
       (match v
         [T/Pair v1 _] v1
         _ (errorf "invalid pair structure in fst: %s" (print/sem v)))
+      (= tag T/Meta) (sem/neutral (ne/fst (ne/meta (get v 1))))
       (= tag T/Neutral) (sem/neutral (ne/fst (get v 1)))
       true (errorf "fst expects a pair value (Σ type), but got: %s"
                    (print/sem v)))))
@@ -633,6 +693,7 @@
       (match v
         [T/Pair _ v2] v2
         _ (errorf "invalid pair structure in snd: %s" (print/sem v)))
+      (= tag T/Meta) (sem/neutral (ne/snd (ne/meta (get v 1))))
       (= tag T/Neutral) (sem/neutral (ne/snd (get v 1)))
       true (errorf "snd expects a pair value (Σ type), but got: %s"
                    (print/sem v)))))
@@ -657,6 +718,9 @@
         (if (sem-eq Av zv xv) dv
           (sem/neutral (ne/J Av xv Pv dv yv pv))))
 
+      (= tag T/Meta)
+      (sem/neutral (ne/J Av xv Pv dv yv pv))
+
       (= tag T/Neutral)
       (sem/neutral (ne/J Av xv Pv dv yv pv))
 
@@ -678,8 +742,9 @@
             [:t-sigma A B] (eval/t-sigma Γ A B)
             [:pair a b] (eval/pair Γ a b)
             [:fst p] (eval/fst Γ p)
-            [:snd p] (eval/snd Γ p)
-             [:t-id A x y] (eval/t-id Γ A x y)
+             [:snd p] (eval/snd Γ p)
+             [:hole name] (meta/value name)
+              [:t-id A x y] (eval/t-id Γ A x y)
              [:t-refl x] (eval/t-refl Γ x)
              [:t-J A x P d y p] (eval/t-J Γ A x P d y p)
              _ tm)))))
@@ -702,10 +767,10 @@
 # Bidirectional checker / metas are installed later.
 (def meta-state
   (meta/make {:ty/type ty/type
+              :T/Meta T/Meta
               :lower lower
               :ctx/lookup ctx/lookup
               :goal-ty T/Type100
-              :goal-term (tm/type 100)
               :print/sem print/sem
               :sem-eq sem-eq}))
 
@@ -716,6 +781,7 @@
                  :T/Refl T/Refl
                  :T/Pair T/Pair
                  :T/Neutral T/Neutral
+                 :T/Meta T/Meta
                  :ty/type ty/type
                  :ty/pi ty/pi
                  :eq-type T/Type100
@@ -730,6 +796,7 @@
                  :ctx/add ctx/add
                  :ctx/lookup ctx/lookup
                  :ne/app ne/app
+                 :ne/meta ne/meta
                  :ne/var ne/var
                  :ne/fst ne/fst
                  :print/sem print/sem
@@ -739,6 +806,7 @@
                   :unify unify/exports}))
 
 (def goals (meta-state :goals))
+(set meta/value (meta-state :meta/value))
 (def goals/set-collect! (meta-state :set-collect!))
 (def goals/collect? (meta-state :collect?))
 (def goals/reset! (meta-state :reset!))
@@ -817,6 +885,7 @@
    :T/Id T/Id
    :T/Refl T/Refl
    :T/Neutral T/Neutral
+   :T/Meta T/Meta
    :T/Pair T/Pair
    :NF/Neut NF/Neut
    :NF/Lam NF/Lam
@@ -844,7 +913,8 @@
    :tm/J tm/J
    :tm/hole tm/hole
    :ne/var ne/var
-   :ne/app ne/app
+    :ne/app ne/app
+    :ne/meta ne/meta
    :ne/fst ne/fst
    :ne/snd ne/snd
    :ne/J ne/J

--- a/src/coreTT.janet
+++ b/src/coreTT.janet
@@ -741,9 +741,13 @@
 (def goals (meta-state :goals))
 (def goals/set-collect! (meta-state :set-collect!))
 (def goals/collect? (meta-state :collect?))
+(def goals/reset! (meta-state :reset!))
 (set infer (checker-state :infer))
 (def check (checker-state :check))
 (def subtype (checker-state :subtype))
+(def infer/c (checker-state :infer/c))
+(def check/c (checker-state :check/c))
+(def infer/constraint (checker-state :infer/constraint))
 
 (defn type-eq [Γ A B]
   (sem-eq T/Type100 (eval Γ A) (eval Γ B)))
@@ -760,6 +764,50 @@
 (defn infer-top [t]
   (let [Γ (ctx/empty)]
     (infer Γ t)))
+
+(defn- hole/fill-name? [name target]
+  (and target
+       (not= target "_")
+       (not= target "?")
+       (= name target)))
+
+(defn- term/fill-hole [tm target solution]
+  (match tm
+    [:hole name] (if (hole/fill-name? name target) solution tm)
+    [:app f a] [:app (term/fill-hole f target solution)
+                     (term/fill-hole a target solution)]
+    [:lam body] [:lam (fn [x] (term/fill-hole (body x) target solution))]
+    [:type _] tm
+    [:t-pi A B] [:t-pi (term/fill-hole A target solution)
+                       (fn [x] (term/fill-hole (B x) target solution))]
+    [:t-sigma A B] [:t-sigma (term/fill-hole A target solution)
+                             (fn [x] (term/fill-hole (B x) target solution))]
+    [:pair l r] [:pair (term/fill-hole l target solution)
+                       (term/fill-hole r target solution)]
+    [:fst p] [:fst (term/fill-hole p target solution)]
+    [:snd p] [:snd (term/fill-hole p target solution)]
+    [:t-id A x y] [:t-id (term/fill-hole A target solution)
+                         (term/fill-hole x target solution)
+                         (term/fill-hole y target solution)]
+    [:t-refl x] [:t-refl (term/fill-hole x target solution)]
+    [:t-J A x P d y p]
+    [:t-J (term/fill-hole A target solution)
+          (term/fill-hole x target solution)
+          (term/fill-hole P target solution)
+          (term/fill-hole d target solution)
+          (term/fill-hole y target solution)
+          (term/fill-hole p target solution)]
+    _ tm))
+
+(defn fill-hole [Γ tm expected hole-name solution]
+  (let [filled (term/fill-hole tm hole-name solution)]
+    (when (= filled tm)
+      (errorf "unknown named hole ?%v" hole-name))
+    {:term filled
+     :check (check/c Γ filled expected)}))
+
+(defn fill-hole-top [tm expected hole-name solution]
+  (fill-hole (ctx/empty) tm expected hole-name solution))
 
 # Public API
 (def exports
@@ -818,15 +866,21 @@
    :type-eq type-eq
    :term-eq term-eq
    :check check
-   :subtype subtype
-   :infer infer
-   :check-top check-top
-   :infer-top infer-top
-    :ctx/empty ctx/empty
+    :subtype subtype
+    :infer infer
+    :check/c check/c
+    :infer/c infer/c
+    :infer/constraint infer/constraint
+    :check-top check-top
+    :infer-top infer-top
+    :fill-hole fill-hole
+    :fill-hole-top fill-hole-top
+     :ctx/empty ctx/empty
     :ctx/add ctx/add
     :ctx/lookup ctx/lookup
     :eval/with-sig eval/with-sig
     :eval/session eval/session
-   :goals goals
-   :goals/set-collect! goals/set-collect!
-   :goals/collect? goals/collect?})
+    :goals goals
+    :goals/set-collect! goals/set-collect!
+    :goals/collect? goals/collect?
+    :goals/reset! goals/reset!})

--- a/src/elab.janet
+++ b/src/elab.janet
@@ -800,4 +800,5 @@
    :record->decls record->decls
    :resolve-decls program/resolve-decls
    :decl/elab (fn [decl] (decl/elab @[] decl))
+   :term/elab-in-sig elab/term
    :term/elab (fn [env node] (elab/term env @[] node))})

--- a/src/meta.janet
+++ b/src/meta.janet
@@ -5,11 +5,14 @@
 (defn make [deps]
   (let [goals @[]
         ctx/lookup (deps :ctx/lookup)
+        T/Meta (deps :T/Meta)
         goal-ty (deps :goal-ty)
-        goal-term (deps :goal-term)
         print/sem (deps :print/sem)
         sem-eq (deps :sem-eq)]
     (var named-goals @{})
+    (var named-metas @{})
+    (var solutions @{})
+    (var next-id 0)
     (var collect? false)
 
     (defn goal/name [name]
@@ -43,6 +46,48 @@
     (defn context-vars [Γ]
       (h/keys Γ))
 
+    (defn fresh-id []
+      (let [id (string "mv" (+ next-id 1))]
+        (++ next-id)
+        id))
+
+    (defn meta/id [name]
+      (if name
+        (or (get named-metas name)
+            (let [id name]
+              (put named-metas name id)
+              id))
+        (fresh-id)))
+
+    (defn meta/value [name]
+      (let [id (meta/id (goal/name name))]
+        (or (get solutions id)
+            [T/Meta id])))
+
+    (defn solve! [name value]
+      (let [id (meta/id (goal/name name))]
+        (put solutions id value)
+        value))
+
+    (defn snapshot []
+      {:goals (array/slice goals)
+       :named-goals (table/clone named-goals)
+       :named-metas (table/clone named-metas)
+       :solutions (table/clone solutions)
+       :next-id next-id
+       :collect? collect?})
+
+    (defn restore! [state]
+      (array/clear goals)
+      (each goal (state :goals)
+        (array/push goals goal))
+      (set named-goals (table/clone (state :named-goals)))
+      (set named-metas (table/clone (state :named-metas)))
+      (set solutions (table/clone (state :solutions)))
+      (set next-id (state :next-id))
+      (set collect? (state :collect?))
+      true)
+
     (defn report [name expected Γ]
       (let [ctx      (map (fn [k] [k (ctx/lookup Γ k)]) (h/keys Γ))
             name     (goal/name name)
@@ -61,6 +106,9 @@
     (defn reset! []
       (array/clear goals)
       (set named-goals @{})
+      (set named-metas @{})
+      (set solutions @{})
+      (set next-id 0)
       true)
 
     (defn set-collect! [enabled]
@@ -74,7 +122,7 @@
       (if collect?
         (do
           (report name goal-ty Γ)
-          goal-term)
+          (meta/value name))
         (errorf "unsolved goal ?%v during inference\nNo expected type is available in inference mode.\nContext variables: %v"
                 name
                 (context-vars Γ))))
@@ -92,6 +140,10 @@
      :context-vars context-vars
      :report report
      :reset! reset!
+     :snapshot snapshot
+     :restore! restore!
+     :meta/value meta/value
+     :solve! solve!
      :set-collect! set-collect!
      :collect? collecting?
      :error-infer error-infer

--- a/src/meta.janet
+++ b/src/meta.janet
@@ -4,13 +4,20 @@
 
 (defn make [deps]
   (let [goals @[]
-        named-goals @{}
         ctx/lookup (deps :ctx/lookup)
         goal-ty (deps :goal-ty)
         goal-term (deps :goal-term)
         print/sem (deps :print/sem)
         sem-eq (deps :sem-eq)]
+    (var named-goals @{})
     (var collect? false)
+
+    (defn goal/name [name]
+      (if (or (nil? name)
+              (= name "_")
+              (= name "?"))
+        nil
+        name))
 
     (defn expected/placeholder? [expected]
       (= expected goal-ty))
@@ -38,6 +45,7 @@
 
     (defn report [name expected Γ]
       (let [ctx      (map (fn [k] [k (ctx/lookup Γ k)]) (h/keys Γ))
+            name     (goal/name name)
             expected (or expected goal-ty)]
         (if-let [goal (and name (get named-goals name))]
           (do
@@ -49,6 +57,11 @@
             (when name (put named-goals name goal))
             (array/push goals goal)
             goal))))
+
+    (defn reset! []
+      (array/clear goals)
+      (set named-goals @{})
+      true)
 
     (defn set-collect! [enabled]
       (set collect? enabled)
@@ -78,6 +91,7 @@
     {:goals goals
      :context-vars context-vars
      :report report
+     :reset! reset!
      :set-collect! set-collect!
      :collect? collecting?
      :error-infer error-infer

--- a/src/print.janet
+++ b/src/print.janet
@@ -7,6 +7,7 @@
         T/Id (deps :T/Id)
         T/Refl (deps :T/Refl)
         T/Neutral (deps :T/Neutral)
+        T/Meta (deps :T/Meta)
         T/Pair (deps :T/Pair)
         NF/Neut (deps :NF/Neut)
         NF/Lam (deps :NF/Lam)
@@ -87,6 +88,7 @@
     (defn atomic-ne? [ne]
       (match ne
         [:nvar _] true
+        [:nmeta _] true
         _ false))
 
     (defn atomic-nf? [nf]
@@ -126,6 +128,7 @@
          (fn [ne]
            (match ne
              [:nvar x] (name x)
+             [:nmeta id] (string "?" id)
              [:napp f x] (string (ne-arg f) " " (nf-arg x))
              [:nfst p] (string "fst " (ne-arg p))
              [:nsnd p] (string "snd " (ne-arg p))
@@ -255,6 +258,7 @@
       (let [tag (tag-of sem)]
         (cond
           (= tag T/Neutral) (print/ne* (get sem 1))
+          (= tag T/Meta) (string "?" (get sem 1))
           (= tag T/Refl) (string "refl " (sem* (get sem 1)))
           (= tag T/Pair) (string "(" (sem* (get sem 1)) ", " (sem* (get sem 2)) ")")
           (or (= tag T/Type) (= tag T/Pi) (= tag T/Sigma) (= tag T/Id))

--- a/src/unify.janet
+++ b/src/unify.janet
@@ -2,124 +2,79 @@
 
 (import ./levels :as lvl)
 
-(defn- unify/assign! [solved mv value]
+(defn- unify/record! [solved mv value]
   (if (has-key? solved mv)
     (when (not= (get solved mv) value)
       (errorf "conflicting solutions for %v" mv))
     (put solved mv value)))
 
-(defn- unify/merge-named! [named name value kind]
-  (when value
-    (if-let [entry (get named name)]
-      (let [other (entry :value)
-            other-kind (entry :kind)]
-        (cond
-          (not= other value)
-          (errorf "named hole ?%v has inconsistent constraints" name)
+(defn- unify/named-evidence [c]
+  (or (c :solution)
+      (and (c :name) (c :expected))))
 
-          (and (= kind :solution) (= other-kind :expected))
-          (put named name {:value value :kind kind})
-
-          true
-          nil))
-      (put named name {:value value :kind kind}))))
+(defn- unify/merge-named! [named c]
+  (when-let [name (c :name)]
+    (when-let [value (unify/named-evidence c)]
+      (if-let [other (get named name)]
+        (when (not= other value)
+          (errorf "named hole ?%v has inconsistent constraints" name))
+        (put named name value)))))
 
 (defn- unify/fill-named! [constraints solved named]
-  (reduce (fn [changed c]
-            (if-not (and (c :name) (nil? (c :solution)))
-              changed
-              (if-let [entry (get named (c :name))]
-                (do (put c :solution (entry :value))
-                    (unify/assign! solved (c :mv) (entry :value))
-                    true)
-                changed)))
-          false
-          constraints))
+  (each c constraints
+    (when (and (c :name) (nil? (c :solution)))
+      (if-let [value (get named (c :name))]
+        (do
+          (put c :solution value)
+          (unify/record! solved (c :mv) value))
+        (when (nil? (c :expected))
+          (errorf "unsolved named hole ?%v" (c :name)))))))
 
-(defn- unify/pattern-unify [term1 term2]
-  "Pattern unification for dependent types"
-  (match [term1 term2]
-    [[:var x] [:var y]] (if (= x y) @{} nil)
-    [[:app f1 a1] [:app f2 a2]]
-    (let [f-sol (unify/pattern-unify f1 f2)
-          a-sol (unify/pattern-unify a1 a2)]
-      (when (and f-sol a-sol)
-        (merge f-sol a-sol)))
-    [[:lam body1] [:lam body2]]
-    (let [fresh (gensym)]
-      (unify/pattern-unify (body1 fresh) (body2 fresh)))
-    _ nil))
-
-(defn- unify/higher-order-step [constraints solved changed]
-  "Perform one step of higher-order unification"
-  (reduce (fn [changed c]
-            (if (c :solution)
-              changed
-              (if-let [expected (c :expected)]
-                (let [dependencies (c :dependencies)
-                      all-deps-solved? (all |(get solved $) dependencies)]
-                  (when all-deps-solved?
-                    (let [solution (unify/pattern-unify [:var (c :mv)] expected)]
-                      (when solution
-                        (unify/assign! solved (c :mv) solution)
-                        (put c :solution solution)
-                        true))))
-                changed)))
-          changed
-          constraints))
-
-(defn- unify/solve-level-constraints [level-constraints]
-  "Solve universe level constraints"
-  (let [solutions @{}
-        constraints (array/slice level-constraints)]
-    # Simple level constraint solver - can be extended later
-    (each constraint constraints
+(defn- unify/check-levels! [constraints]
+  (defn ground-level [l]
+    (let [norm (lvl/closed l)]
+      (if (int? norm) norm nil)))
+  (each c constraints
+    (each constraint (c :level-constraints)
       (match constraint
         [:eq l1 l2]
-        (when (and (lvl/const? l1) (lvl/const? l2))
-          (when (not= (l1 1) (l2 1))
-            (errorf "level constraint violation: %v != %v" l1 l2)))
+        (let [g1 (ground-level l1)
+              g2 (ground-level l2)]
+          (when (and (not (nil? g1)) (not (nil? g2)))
+            (when (not= g1 g2)
+              (errorf "level constraint violation: %v != %v" l1 l2))))
+
         [:leq l1 l2]
-        (when (and (lvl/const? l1) (lvl/const? l2))
-          (when (> (l1 1) (l2 1))
-            (errorf "level constraint violation: %v > %v" l1 l2)))
-        _ nil))
-    solutions))
+        (let [g1 (ground-level l1)
+              g2 (ground-level l2)]
+          (when (and (not (nil? g1)) (not (nil? g2)))
+            (when (> g1 g2)
+              (errorf "level constraint violation: %v > %v" l1 l2))))
+
+        _ nil))))
 
 (defn unify/solve [constraints]
+  "Reconcile named-hole evidence and validate level constraints.
+
+  This is intentionally not a higher-order unifier. The only live semantics
+  today are:
+  - explicit `:solution` values remain authoritative
+  - named constraints may use their `:expected` type as report-time evidence
+  - that evidence propagates to other constraints with the same name
+  - level constraints are validated when they are ground"
   (let [solved @{}
-        named  @{}]
-    # First pass: solve simple constraints
+        named @{}]
     (each c constraints
-      (let [mv    (c :mv)
-            value (or (c :solution) (c :expected))
-            kind  (if (c :solution) :solution :expected)
-            name  (c :name)]
-        (when value
-          (unify/assign! solved mv value)
-          (put c :solution value))
-        (when name
-          (unify/merge-named! named name value kind))))
+      (when-let [value (c :solution)]
+        (unify/record! solved (c :mv) value))
+      (unify/merge-named! named c))
 
-    (while (unify/fill-named! constraints solved named))
-
-    # Solve level constraints
-    (let [level-constraints (reduce (fn [acc c]
-                                      (array/concat acc (c :level-constraints)))
-                                    @[]
-                                    constraints)]
-      (unify/solve-level-constraints level-constraints))
-
-    # Higher-order unification for dependent constraints
-    (var changed true)
-    (var iterations 0)
-    (while (and changed (< iterations 100))
-      (set changed (unify/higher-order-step constraints solved false))
-      (++ iterations))
+    (unify/fill-named! constraints solved named)
+    (unify/check-levels! constraints)
 
     (each c constraints
-      (when (and (c :name) (nil? (c :solution)))
-        (errorf "unsolved named hole ?%v" (c :name))))
+      (when-let [value (c :solution)]
+        (unify/record! solved (c :mv) value)))
 
     solved))
 

--- a/test/Constraints/ConstraintGeneration.janet
+++ b/test/Constraints/ConstraintGeneration.janet
@@ -1,16 +1,43 @@
 #!/usr/bin/env janet
 
 (import ../Utils/TestRunner :as test)
+(import ../../src/constraints :as c)
+(import ../../src/levels :as lvl)
+(import ../../src/unify :as u)
 
-(defn test-constraints []
-  (test/start-suite "Constraints")
-  
-  # Test basic constraint functions
-  (test/assert true "Constraint functions are available")
-  
-  # Test constraint generation infrastructure
-  # Note: More sophisticated tests will be added as constraint functionality grows
-  
-  (test/end-suite))
+(def suite (test/start-suite "Constraints"))
 
-(test-constraints)
+(test/assert suite
+  (let [constraints @[(c/constraint/make '?mv1 "goal" nil nil @[] :test)
+                      (c/constraint/make '?mv2 "goal" [:type 0] nil @[] :test)]
+        solved (u/unify/solve constraints)]
+    (and (= (length solved) 2)
+         (= ((constraints 0) :solution) [:type 0])
+         (= ((constraints 1) :solution) [:type 0])))
+  "Named expected evidence propagates across matching constraints")
+
+(test/assert suite
+  (let [constraints @[(c/constraint/make '?mv nil [:type 0] nil @[] :test)]
+        solved (u/unify/solve constraints)]
+    (and (= (length solved) 0)
+         (nil? ((constraints 0) :solution))))
+  "Anonymous expected constraints stay unsolved")
+
+(test/assert-error suite
+  (fn []
+    (u/unify/solve @[(c/constraint/make '?mv1 "goal" [:type 0] nil @[] :test)
+                     (c/constraint/make '?mv2 "goal" [:type 1] nil @[] :test)]))
+  "Named constraints reject inconsistent evidence")
+
+(test/assert-error suite
+  (fn []
+    (u/unify/solve @[(c/constraint/make '?mv "goal" nil nil @[] :test)]))
+  "Named constraints without evidence remain errors")
+
+(test/assert-error suite
+  (fn []
+    (u/unify/solve @[(c/constraint/make '?mv nil nil nil @[] :test @[]
+                                        @[[:eq (lvl/closed 0) (lvl/closed 1)]])]))
+  "Ground level inconsistencies are rejected")
+
+(test/end-suite suite)

--- a/test/Core/Evaluation.janet
+++ b/test/Core/Evaluation.janet
@@ -61,6 +61,20 @@
     (= (c/eval Γ1 [:var fresh]) [c/T/Neutral [:nvar fresh]])
     "Symbol variables (gensyms) evaluate to neutrals"))
 
+(test/assert suite
+  (= (c/eval (c/ctx/empty) [:hole "goal"])
+     [c/T/Meta "goal"])
+  "Named holes survive evaluation as semantic metas")
+
+(test/assert suite
+  (= (c/eval (c/ctx/empty) [:fst [:hole "pair-goal"]])
+     [c/T/Neutral [:nfst [:nmeta "pair-goal"]]])
+  "Metas survive projections through neutral structure")
+
+(test/assert suite
+  (c/term-eq (c/ctx/empty) (c/ty/type 0) [:hole "goal"] [:hole "goal"])
+  "Semantic equality treats the same named meta as rigidly equal")
+
 (let [dom (c/ty/pi (c/ty/type 0) (fn [_] (c/ty/type 0)))
       Γ (c/ctx/add (c/ctx/empty) "f" (c/ty/pi dom (fn [_] (c/ty/type 0))))
       sem (c/eval Γ [:app [:var "f"] [:lam (fn [x] [:var x])]])

--- a/test/Core/Meta.janet
+++ b/test/Core/Meta.janet
@@ -40,4 +40,24 @@
       ((state :error-check) "named" [:type 1] (ctx @[]))))
   "Named goals reject inconsistent expected types")
 
+(test/assert suite
+  (let [state (make-state)]
+    ((state :set-collect!) true)
+    ((state :reset!))
+    ((state :error-check) "_" [:type 0] (ctx @[]))
+    ((state :error-check) "_" [:type 1] (ctx @[]))
+    (let [goals (state :goals)]
+      (and (= (length goals) 2)
+           (nil? ((goals 0) :name))
+           (nil? ((goals 1) :name)))))
+  "Underscore holes stay anonymous across goal collection")
+
+(test/assert suite
+  (let [state (make-state)]
+    ((state :set-collect!) true)
+    ((state :error-check) "named" [:type 0] (ctx @[]))
+    ((state :reset!))
+    (= (length (state :goals)) 0))
+  "Meta state reset clears collected goals")
+
 (test/end-suite suite)

--- a/test/Elab/Interactive.janet
+++ b/test/Elab/Interactive.janet
@@ -1,16 +1,39 @@
 #!/usr/bin/env janet
 
 (import ../Utils/TestRunner :as test)
+(import ../../src/coreTT :as tt)
+(import ../../src/elab :as e)
 
-(defn test-interactive-elab []
-  (test/start-suite "Interactive Elaboration")
-  
-  # Test interactive elaboration infrastructure
-  (test/assert true "Interactive elaboration infrastructure available")
-  
-  # TODO: Add actual interactive elaboration tests once the implementation is complete
-  # This test file will be expanded as interactive elaboration functionality grows
-  
-  (test/end-suite))
+(def suite (test/start-suite "Interactive Elaboration"))
 
-(test-interactive-elab)
+(def Type1 (tt/ty/type 1))
+
+(test/assert suite
+  (let [term ((e/exports :term/elab) @[] [:atom "?goal"])
+        result (tt/check/c (tt/ctx/empty) term Type1)
+        constraints (result :constraints)]
+    (and (= (length constraints) 1)
+         (= ((constraints 0) :name) "goal")
+         (= (((constraints 0) :expected) 0) tt/T/Type)
+         (nil? ((constraints 0) :solution))))
+  "Elaborated named holes become live checking constraints")
+
+(test/assert suite
+  (let [term [:pair [:hole "goal"] [:hole "goal"]]
+        sigma (tt/ty/sigma Type1 (fn [_] Type1))
+        initial (tt/check/c (tt/ctx/empty) term sigma)
+        filled (tt/fill-hole-top term sigma "goal" (tt/tm/type 0))
+        check (filled :check)]
+    (and (= (length (initial :constraints)) 1)
+         (nil? (check :error))
+         (= (length (check :constraints)) 0)
+         (= (filled :term) [:pair [:type 0] [:type 0]])))
+  "Filling one named hole updates all occurrences and rechecks the term")
+
+(test/assert suite
+  (let [sigma (tt/ty/sigma Type1 (fn [_] Type1))
+        failed (tt/fill-hole-top [:hole "goal"] sigma "goal" (tt/tm/type 0))]
+    (not (nil? ((failed :check) :error))))
+  "Ill-typed hole fillings are rejected by the live checking path")
+
+(test/end-suite suite)

--- a/test/Regression/CliFill.sh
+++ b/test/Regression/CliFill.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$repo_root"
+
+check_output=$(janet requiem.janet check "examples/hole-fill.requiem")
+case "$check_output" in
+  *"?goal : Nat"*) ;;
+  *)
+    printf 'expected check output to mention the Nat goal\n' >&2
+    exit 1
+    ;;
+esac
+
+fill_check_output=$(janet requiem.janet fill "examples/hole-fill.requiem" goal "zero")
+case "$fill_check_output" in
+  *"Target: check block 1"*"Filled ?goal with zero"*"=> zero"*) ;;
+  *)
+    printf 'expected fill output for check block target\n' >&2
+    exit 1
+    ;;
+esac
+
+fill_clause_output=$(janet requiem.janet fill "examples/clause-hole-fill.requiem" goal "zero")
+case "$fill_clause_output" in
+  *"Target: function id clause 1"*"Filled ?goal with zero"*"=> zero"*) ;;
+  *)
+    printf 'expected fill output for function clause target\n' >&2
+    exit 1
+    ;;
+esac
+
+if janet requiem.janet fill "examples/clause-hole-fill.requiem" goal "Type0" >/tmp/requiem-cli-fill.err 2>&1; then
+  printf 'expected ill-typed fill to fail\n' >&2
+  exit 1
+fi
+
+bad_fill_output=$(< /tmp/requiem-cli-fill.err)
+case "$bad_fill_output" in
+  *"type mismatch between expected type and inferred type"*) ;;
+  *)
+    printf 'expected ill-typed fill error output\n' >&2
+    exit 1
+    ;;
+esac
+
+rm -f /tmp/requiem-cli-fill.err
+printf 'CLI fill regression script passed\n'


### PR DESCRIPTION
## Summary
- wire constraint collection into the live CoreTT checking path and expose typed hole-filling helpers through `coreTT`
- tighten `unify.janet` to the semantics the codebase actually uses, and add regression tests for named-goal reconciliation and CLI fill behavior
- route `requiem` through the live reporting/checking path and add `requiem fill` support for both check blocks and function clauses

## Testing
- jpm test
- bash test/Regression/CliFill.sh